### PR TITLE
Add SQLite3::VERSION

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -31,4 +31,6 @@ void Init_sqlite3_native()
   init_sqlite3_backup();
 
   rb_define_singleton_method(mSqlite3, "libversion", libversion, 0);
+  rb_define_const(mSqlite3, "SQLITE_VERSION", rb_str_new2(SQLITE_VERSION));
+  rb_define_const(mSqlite3, "SQLITE_VERSION_NUMBER", INT2FIX(SQLITE_VERSION_NUMBER));
 }

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -13,4 +13,5 @@ module SQLite3
     VERSION = '1.3.1'
   end
 
+    VERSION = Version::VERSION
 end


### PR DESCRIPTION
Hi,

I'll commit this change on next week.
If you have a comment, please tell me.

Thanks,

---

Add SQLite3::VERSION etc.

Bundled extension library of Ruby has some constants.
For example, zlib has following:
- Zlib::VERSION is the version of the zlib wrapper.
- Zlib::ZLIB_VERSION is the version of the linked zlib.

So following constants are added to sqlite3-ruby:
- SQLite3::VERSION is the version of sqlite3-ruby
- SQLite3::SQLITE_VERSION is the version of linked sqlite3.
- SQLite3::SQLITE_VERSION_NUMBER is the numeric version of linked sqlite3.
