### PR TITLE
statement.execute only works once for inserts

### DIFF
--- a/lib/sqlite3/statement.rb
+++ b/lib/sqlite3/statement.rb
@@ -33,6 +33,7 @@ module SQLite3
     # See also #execute, #bind_param, Statement#bind_param, and
     # Statement#bind_params.
     def bind_params( *bind_vars )
+      reset! if active? || done?
       index = 1
       bind_vars.flatten.each do |var|
         if Hash === var


### PR DESCRIPTION
the checkin to allow a prepared statement to execute without calling finish isn't quite enough.  the upper level dbi statement code is going to call bind_params before calling execute, and by then it's too late.
