### PR TITLE
Proposed patch for issue 29

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -716,6 +716,20 @@ static VALUE db_encoding(VALUE self)
   return rb_iv_get(self, "@encoding");
 }
 
+/* call-seq: db.transaction_active?
+ *
+ * Returns +true+ if there is a transaction active, and +false+ otherwise.
+ *
+ */
+static VALUE transaction_active_p(VALUE self)
+{
+  sqlite3RubyPtr ctx;
+  Data_Get_Struct(self, sqlite3Ruby, ctx);
+  REQUIRE_OPEN_DB(ctx);
+
+  return sqlite3_get_autocommit(ctx->db) ? Qfalse : Qtrue;
+}
+
 void init_sqlite3_database()
 {
   ID id_utf16, id_results_as_hash, id_type_translation;
@@ -742,6 +756,7 @@ void init_sqlite3_database()
   rb_define_method(cSqlite3Database, "authorizer=", set_authorizer, 1);
   rb_define_method(cSqlite3Database, "busy_handler", busy_handler, -1);
   rb_define_method(cSqlite3Database, "busy_timeout=", set_busy_timeout, 1);
+  rb_define_method(cSqlite3Database, "transaction_active?", transaction_active_p, 0);
 
 #ifdef HAVE_SQLITE3_LOAD_EXTENSION
   rb_define_method(cSqlite3Database, "load_extension", load_extension, 1);

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -482,7 +482,6 @@ Support for this will be removed in version 2.0.0.
     # #rollback.
     def transaction( mode = :deferred )
       execute "begin #{mode.to_s} transaction"
-      @transaction_active = true
 
       if block_given?
         abort = false
@@ -505,7 +504,6 @@ Support for this will be removed in version 2.0.0.
     # <tt>abort? and rollback or commit</tt>.
     def commit
       execute "commit transaction"
-      @transaction_active = false
       true
     end
 
@@ -515,13 +513,7 @@ Support for this will be removed in version 2.0.0.
     # <tt>abort? and rollback or commit</tt>.
     def rollback
       execute "rollback transaction"
-      @transaction_active = false
       true
-    end
-
-    # Returns +true+ if there is a transaction active, and +false+ otherwise.
-    def transaction_active?
-      @transaction_active
     end
 
     # Returns +true+ if the database has been open in readonly mode

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -454,6 +454,17 @@ class TC_Database_Integration < Test::Unit::TestCase
     assert !@db.transaction_active?
   end
 
+  def test_transaction_implicit_rollback
+    assert !@db.transaction_active?
+    @db.transaction 
+    @db.execute('create table bar (x CHECK(1 = 0))')
+    assert @db.transaction_active?
+    assert_raises( SQLite3::ConstraintException ) do
+      @db.execute("insert or rollback into bar (x) VALUES ('x')")
+    end
+    assert !@db.transaction_active?
+  end
+
   def test_interrupt
     @db.create_function( "abort", 1 ) do |func,x|
       @db.interrupt


### PR DESCRIPTION
sqlite3_get_autocommit is the existing C API for this.  I don't know if you want to do more compatibility checking WRT earlier SQLite 3 versions or such; the C API reference doesn't declare an earliest version for it.  Let me know what you think.
