### PR TITLE
Patch for #31 - SQLite Statement Encoding

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -45,10 +45,7 @@ static VALUE initialize(VALUE self, VALUE db, VALUE sql)
 
 #ifdef HAVE_RUBY_ENCODING_H
   if(!UTF8_P(sql)) {
-    VALUE encoding    = rb_funcall(db, rb_intern("encoding"), 0);
-    rb_encoding * enc = NIL_P(encoding) ? rb_utf8_encoding() :
-                                          rb_to_encoding(encoding);
-    sql               = rb_str_export_to_enc(sql, enc);
+    sql               = rb_str_export_to_enc(sql, rb_utf8_encoding());
   }
 #endif
 


### PR DESCRIPTION
This patch to statement.c converts non-UTF-8 inbound statements to UTF-8 prior to calling sqlite3_prepare_v2. This resolves both the UTF-16 database and encrypted database compatibility problems described in issue #31. Thanks so much for the quick response! 
