### PR TITLE
HashWithTypes gives duplicate values

### DIFF
--- a/lib/sqlite3/resultset.rb
+++ b/lib/sqlite3/resultset.rb
@@ -25,8 +25,14 @@ module SQLite3
 
     # The class of which we return an object in case we want a Hash as
     # result.
-    class HashWithTypes < Hash
+    class HashWithTypesAndFields < Hash
       attr_accessor :types
+      attr_accessor :fields
+      
+      def [] key
+        key = fields[key] if key.is_a? Numeric
+        super key
+      end
     end
 
     # Create a new ResultSet attached to the given database, using the
@@ -73,11 +79,8 @@ module SQLite3
       end
 
       if @db.results_as_hash
-        new_row = HashWithTypes[*@stmt.columns.zip(row).flatten]
-        row.each_with_index { |value,idx|
-          new_row[idx] = value
-        }
-        row = new_row
+        row = HashWithTypesAndFields[*@stmt.columns.zip(row).flatten]
+        row.fields = @stmt.columns
       else
         if row.respond_to?(:fields)
           row = ArrayWithTypes.new(row)

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -98,8 +98,11 @@ class TC_ResultSet < Test::Unit::TestCase
   def test_next_results_as_hash
     @db.results_as_hash = true
     @result.reset( 1 )
-    assert_equal( { "a" => 1, "b" => "foo", 0 => 1, 1 => "foo" },
-      @result.next )
+    hash = @result.next
+    assert_equal( { "a" => 1, "b" => "foo" },
+      hash )
+    assert_equal hash[0], 1
+    assert_equal hash[1], "foo"
   end
 
   def test_tainted_results_as_hash


### PR DESCRIPTION
Modified `HashWithTypes` to have a list of fields and also fake hash access by offset.

I was trying to use `Hash#to_json` and fields on an SQLite3 result row with `results_as_hash` on which meant I was getting duplicate values everywhere, keyed once by column name and once by offset. Instead, give the desired hash-like behaviour with the offset-accessors as a bonus on `HashWithTypesAndFields`. I changed the class name to reflect changed behaviour a la `ArrayWithTypesAndFields` and force a re-think for people dipping deep into the library.

Perhaps this isn't the best backwards-compatible approach, but I thought this could start a discussion.

Thanks!

P.S. Sorry for the rad commit message, my fingers apparently tripped over the keyboard.
