### PR TITLE
Prepared parametrized statement fails if previous execution has raised error.

### DIFF
--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -209,5 +209,14 @@ module SQLite3
       stmt = @db.prepare('select :n, :h')
       assert_equal [[10, nil]], stmt.execute('n' => 10, 'h' => nil).to_a
     end
+    
+    def test_with_error
+      @db.execute('CREATE TABLE "employees" ("name" varchar(20) NOT NULL CONSTRAINT "index_employees_on_name" UNIQUE)')
+      stmt = @db.prepare("INSERT INTO Employees(name) VALUES(?)")
+      stmt.execute('employee-1')
+      stmt.execute('employee-1') rescue SQLite3::ConstraintException
+      assert_nothing_raised(SQLite3::ConstraintException) { stmt.execute('employee-2') }
+    end
+
   end
 end


### PR DESCRIPTION
Following scenario causes error:
- Suppose we have a table Employees with unique column "name"
- Prepare parametrized statement that inserts new employee with name as parameter
- Bind and execute statement with paramenter "employee-1"
- Do the same again. As expected constraint exception is raised which is correct
- Bind and execute statement with paramenter "employee-2".  The statement fails with previous error!

Pull request includes test to reproduce the issue.
