### PR TITLE
Fix for #52

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -255,12 +255,12 @@ static VALUE bind_param(VALUE self, VALUE key, VALUE value)
       }
       break;
     case T_BIGNUM:
-#if SIZEOF_LONG < 8
+// #if SIZEOF_LONG < 8
       if (RBIGNUM_LEN(value) * SIZEOF_BDIGITS <= 8) {
           status = sqlite3_bind_int64(ctx->st, index, (sqlite3_int64)NUM2LL(value));
           break;
       }
-#endif
+// #endif
     case T_FLOAT:
       status = sqlite3_bind_double(ctx->st, index, NUM2DBL(value));
       break;

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -11,6 +11,17 @@ module SQLite3
     def test_segv
       assert_raises(TypeError) { SQLite3::Database.new 1 }
     end
+    
+    def test_sqlite3_int64_binding
+      #Min and max values for sqlite3_int64: http://www.sqlite.org/capi3ref.html#sqlite3_int64
+      min = -9223372036854775808
+      max = 9223372036854775807
+      db.execute 'CREATE TABLE "sqlite3_int64_test" ("min" integer(8), "max" integer(8))'
+      db.execute "INSERT INTO sqlite3_int64_test(min, max) VALUES(?, ?)", [min, max]
+      rows = db.execute 'select min, max from sqlite3_int64_test'
+      assert_equal min, rows.first.first
+      assert_equal max, rows.first.last
+    end
 
     def test_bignum
       num = 4907021672125087844


### PR DESCRIPTION
IMHO "#if SIZEOF_LONG < 8" [statement.c#L258](https://github.com/luislavena/sqlite3-ruby/blob/master/ext/sqlite3/statement.c#L258) should not be here.  Next statement "if (RBIGNUM_LEN(value) \* SIZEOF_BDIGITS <= 8)" [statement.c#L259](https://github.com/luislavena/sqlite3-ruby/blob/master/ext/sqlite3/statement.c#L259) has same result on 32 and 64 bit archs since RBIGNUM_LEN(value) and SIZEOF_BDIGITS return same values on both archs. So code binding of T_BIGNUM (without #if...) has the same results for both archs.

Just removing the define fixes #52. I have also added extra test to make sure min/max are bound correctly. All tests are passed (including that failing one that reproduces #52) on both archs. The tests was executed on OSX.
