### PR TITLE
use SQLITE3_UTF8_STR_NEW2 at returning column name

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -363,7 +363,7 @@ static VALUE column_name(VALUE self, VALUE index)
 
   name = sqlite3_column_name(ctx->st, (int)NUM2INT(index));
 
-  if(name) return rb_str_new2(name);
+  if(name) return SQLITE3_UTF8_STR_NEW2(name);
   return Qnil;
 }
 


### PR DESCRIPTION
Now column_name in statement.c returns string as ASCII-8BIT.
It is unconvenient that to_yaml includes '!binary' on rails.
I hope to get it as UTF-8.
