### PR TITLE
Resolves bug #65

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -281,9 +281,16 @@ static VALUE sqlite3val2rb(sqlite3_value * val)
     case SQLITE_TEXT:
       return rb_tainted_str_new2((const char *)sqlite3_value_text(val));
       break;
-    case SQLITE_BLOB:
-      return rb_tainted_str_new2((const char *)sqlite3_value_blob(val));
+    case SQLITE_BLOB: {
+      /* Sqlite warns calling sqlite3_value_bytes may invalidate pointer from sqlite3_value_blob,
+         so we explicitly get the length before getting blob pointer.
+         Note that rb_str_new and rb_tainted_str_new apparently create string with ASCII-8BIT (BINARY) encoding,
+         which is what we want, as blobs are binary
+       */
+      int len = sqlite3_value_bytes(val);
+      return rb_tainted_str_new((const char *)sqlite3_value_blob(val), len);
       break;
+    }
     case SQLITE_NULL:
       return Qnil;
       break;


### PR DESCRIPTION
This patch resolves #65 by properly converting blobs into ruby strings.
