### PR TITLE
Handle trailing newline in default strings

### DIFF
--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -269,9 +269,9 @@ module SQLite3
         case hash["dflt_value"]
         when /^null$/i
           hash["dflt_value"] = nil
-        when /^'(.*)'$/
+        when /^'(.*)'$/m
           hash["dflt_value"] = $1.gsub(/''/, "'")
-        when /^"(.*)"$/
+        when /^"(.*)"$/m
           hash["dflt_value"] = $1.gsub(/""/, '"')
         end
       end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -21,12 +21,14 @@ class TC_Database_Integration < SQLite3::TestCase
 
   def test_table_info_with_defaults_for_version_3_3_8_and_higher
     @db.transaction do
-      @db.execute "create table defaults_test ( a string default NULL, b string default 'Hello' )"
+      @db.execute "create table defaults_test ( a string default NULL, b string default 'Hello', c string default '--- []\n' )"
       data = @db.table_info( "defaults_test" )
       assert_equal({"name" => "a", "type" => "string", "dflt_value" => nil, "notnull" => 0, "cid" => 0, "pk" => 0},
         data[0])
       assert_equal({"name" => "b", "type" => "string", "dflt_value" => "Hello", "notnull" => 0, "cid" => 1, "pk" => 0},
         data[1])
+      assert_equal({"name" => "c", "type" => "string", "dflt_value" => "--- []\n", "notnull" => 0, "cid" => 2, "pk" => 0},
+        data[2])
     end
   end
 


### PR DESCRIPTION
I ran into this when trying to use ActiveRecord's Array serialization. Since the `tweak_default` regexes were only matching against non-newline characters, newlines in the default value for a string column mean you get hosed with `ActiveRecord::SerializationTypeMismatch`. This is since sqlite3 thinks the default value is `"'--- []\n'"` instead of `"--- []\n"`.

I'm happy to change things about this patch if there are tweaks :trollface: you'd like to see. Let me know.
