### PR TITLE
added another insert example to readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,9 +34,9 @@ Note that this module is only compatible with SQLite 3.6.16 or newer.
     db.execute "insert into numbers values ( ?, ? )", pair
   end
 
-  # Execute multi-inserts
+  # Execute inserts with parameter markers
   db.execute("INSERT INTO students (name, email, grade, blog) 
-              VALUES (?, ?, ?, ?)", @name, @email, @grade, @blog)
+              VALUES (?, ?, ?, ?)", [@name, @email, @grade, @blog])
   
   # Find a few rows
   db.execute( "select * from numbers" ) do |row|


### PR DESCRIPTION
a group of new programmers used this gem for a project today. We didn't realize that it supported the multi-insert syntax included here and a bunch of us ended up jumping through hoops and manually escaping characters ourselves. Added an example to README to make it clear this feature is supported.

Thanks!
