### PR TITLE
Allow rbx 1.8 & 1.9 modes to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,18 @@ before_script:
   - gem install hoe
   - gem install rake-compiler
   - gem install mini_portile
+language: ruby
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - ruby-head
+  - rbx-18mode
+  - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: rbx-18mode
+    - rvm: rbx-19mode
 env:
   - USE_MINI_PORTILE=true
   - USE_MINI_PORTILE=false


### PR DESCRIPTION
In support of rubinius/rubinius#2006 we're trying to get important gems with C-extensions to test on Rubinius.

Thanks for your consideration!
