### PR TITLE
Reset before CHECKing the status

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -186,6 +186,8 @@ static VALUE step(VALUE self)
       return Qnil;
       break;
     default:
+      sqlite3_reset(stmt);
+      ctx->done_p = 0;
       CHECK(sqlite3_db_handle(ctx->st), value);
   }
 

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -24,6 +24,15 @@ module SQLite3
       end
     end
 
+    def test_insert_duplicate_records
+      @db.execute 'CREATE TABLE "things" ("name" varchar(20) CONSTRAINT "index_things_on_name" UNIQUE)'
+      stmt = @db.prepare("INSERT INTO things(name) VALUES(?)")
+      stmt.execute('ruby')
+
+      exception = assert_raises(SQLite3::ConstraintException) { stmt.execute('ruby') }
+      assert_match /column(s)? .* (is|are) not unique/, exception.message
+    end
+
     ###
     # This method may not exist depending on how sqlite3 was compiled
     def test_database_name


### PR DESCRIPTION
Hi,

When `SQLite3::ConstraintException` is raised, the error message will always be `"constraint failed"`, which isn't helpful enough. So `sqlite3_reset()` should be called before CHECKing to get more specific error messages from `sqlite3_errmsg()`.

This design is described on `sqlite3_step()`'s documentation at: http://www.sqlite.org/c3ref/step.html

> In the legacy interface, the sqlite3_step() API always returns a generic error code, SQLITE_ERROR, following any error other than SQLITE_BUSY and SQLITE_MISUSE. You must call sqlite3_reset() or sqlite3_finalize() in order to find one of the specific error codes that better describes the error. We admit that this is a goofy design. The problem has been fixed with the "v2" interface. If you prepare all of your SQL statements using either sqlite3_prepare_v2() or sqlite3_prepare16_v2() instead of the legacy sqlite3_prepare() and sqlite3_prepare16() interfaces, then the more specific error codes are returned directly by sqlite3_step(). The use of the "v2" interface is recommended.
