### PR TITLE
Add cross compilation for x64-mingw32.

### DIFF
--- a/tasks/native.rake
+++ b/tasks/native.rake
@@ -26,7 +26,7 @@ Rake::ExtensionTask.new('sqlite3_native', HOE.spec) do |ext|
     ext.config_options << "--enable-local"
   else
     ext.cross_compile = true
-    ext.cross_platform = ['i386-mswin32-60', 'i386-mingw32']
+    ext.cross_platform = ['i386-mswin32-60', 'i386-mingw32', 'x64-mingw32']
     ext.cross_config_options << "--enable-local"
   end
 end


### PR DESCRIPTION
Regarding to https://github.com/luislavena/rake-compiler/pull/74#issuecomment-17479502 :

I didn't use mini_portile till now. ruby-pg and fxruby both use it's own tasks for building required libraries. Nevertheless you might use something like the attached proposal.
