### PR TITLE
Adds missing name method from rdoc for create_aggregate_handler

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -431,6 +431,7 @@ Support for this will be removed in version 2.0.0.
     #
     #   class LengthsAggregateHandler
     #     def self.arity; 1; end
+    #     def self.name; 'lengths'; end
     #
     #     def initialize
     #       @total = 0


### PR DESCRIPTION
The `LengthsAggregateHandler` rdoc example was missing the required `name` method which meant the example wouldn't run verbatim.
