### PR TITLE
Fix for new unique constraint message of SQLite 3.8.2 in test

### DIFF
--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -30,7 +30,11 @@ module SQLite3
       stmt.execute('ruby')
 
       exception = assert_raises(SQLite3::ConstraintException) { stmt.execute('ruby') }
-      assert_match /column(s)? .* (is|are) not unique/, exception.message
+      # SQLite 3.8.2 returns new error message:
+      #   UNIQUE constraint failed: *table_name*.*column_name*
+      # Older versions of SQLite return:
+      #   column *column_name* is not unique
+      assert_match /(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/, exception.message
     end
 
     ###


### PR DESCRIPTION
SQLite 3.8.2 changed its error messages format for unique constrains and now our tests in Fedora fails. This fixes the issue.

```
+ testrb -Ilib test/test_backup.rb test/test_collation.rb test/test_database.rb test/test_database_readonly.rb test/test_deprecated.rb test/test_encoding.rb test/test_integration.rb test/test_integration_open_close.rb test/test_integration_pending.rb test/test_integration_resultset.rb test/test_integration_statement.rb test/test_result_set.rb test/test_sqlite3.rb test/test_statement.rb test/test_statement_execute.rb
Run options: -Ilib
# Running tests:
.......................................................................................F........................................................................................S..................................................
Finished tests in 3.438005s, 66.0267 tests/s, 108.7840 assertions/s.
  1) Failure:
SQLite3::TestStatement#test_insert_duplicate_records [/builddir/build/BUILD/sqlite3-1.3.8/usr/share/gems/gems/sqlite3-1.3.8/test/test_statement.rb:33]:
Expected /column(s)? .* (is|are) not unique/ to match "UNIQUE constraint failed: things.name".
227 tests, 374 assertions, 1 failures, 0 errors, 1 skips
```

This fixes https://github.com/sparklemotion/sqlite3-ruby/issues/116
