### PR TITLE
Don't depend on Bignum representation

### DIFF
--- a/ext/sqlite3/compat.c
+++ b/ext/sqlite3/compat.c
@@ -1,0 +1,22 @@
+#include <sqlite3_ruby.h>
+
+int sqlite3_ruby_bignum2int64(sqlite3_int64 *n, VALUE bignum)
+{
+#ifdef RBIGNUM
+  /* Ruby < 2.2.0 */
+  if (RBIGNUM_LEN(bignum) * SIZEOF_BDIGITS <= 8) {
+    *n = (sqlite3_int64)NUM2LL(bignum);
+    return 1;
+  } else {
+    return 0;
+  }
+#else
+  /* Ruby >= 2.2.0 */
+  int sign = rb_integer_pack(bignum, n, 1, sizeof(*n), 0, INTEGER_PACK_LSWORD_FIRST | INTEGER_PACK_NATIVE_BYTE_ORDER | INTEGER_PACK_2COMP);
+  if (-1 <= sign && sign <= 1) {
+    return 1;
+  } else {
+    return 0;
+  }
+#endif
+}

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -310,9 +310,12 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
       break;
     case T_BIGNUM:
 #if SIZEOF_LONG < 8
-      if (RBIGNUM_LEN(result) * SIZEOF_BDIGITS <= 8) {
-          sqlite3_result_int64(ctx, NUM2LL(result));
+      {
+        sqlite3_int64 n;
+        if (sqlite3_ruby_bignum2int64(&n, result)) {
+          sqlite3_result_int64(ctx, n);
           break;
+        }
       }
 #endif
     case T_FLOAT:

--- a/ext/sqlite3/sqlite3_ruby.h
+++ b/ext/sqlite3/sqlite3_ruby.h
@@ -51,4 +51,6 @@ extern VALUE cSqlite3Blob;
 #include <exception.h>
 #include <backup.h>
 
+int sqlite3_ruby_bignum2int64(sqlite3_int64 *n, VALUE bignum);
+
 #endif

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -268,9 +268,12 @@ static VALUE bind_param(VALUE self, VALUE key, VALUE value)
       }
       break;
     case T_BIGNUM:
-      if (RBIGNUM_LEN(value) * SIZEOF_BDIGITS <= 8) {
-          status = sqlite3_bind_int64(ctx->st, index, (sqlite3_int64)NUM2LL(value));
+      {
+        sqlite3_int64 n;
+        if (sqlite3_ruby_bignum2int64(&n, value)) {
+          status = sqlite3_bind_int64(ctx->st, index, n);
           break;
+        }
       }
     case T_FLOAT:
       status = sqlite3_bind_double(ctx->st, index, NUM2DBL(value));


### PR DESCRIPTION
From Ruby 2.2.0, RBignum is hidden.
https://bugs.ruby-lang.org/issues/6083
