### PR TITLE
If boolean is stored as an integer, fix type translation for boolean

### DIFF
--- a/lib/sqlite3/translator.rb
+++ b/lib/sqlite3/translator.rb
@@ -95,6 +95,7 @@ Built in translators are deprecated and will be removed in version 2.0.0
         "bool",
         "boolean" ].each do |type|
         add_translator( type ) do |t,v|
+          v = v.to_s
           !( v.strip.gsub(/00+/,"0") == "0" ||
              v.downcase == "false" ||
              v.downcase == "f" ||

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -363,5 +363,13 @@ module SQLite3
     def test_execute_with_named_bind_params
       assert_equal [['foo']], @db.execute("select :n", {'n' => 'foo'})
     end
+
+    def test_boolean_type_translation
+      db = SQLite3::Database.new(':memory:', type_translation: true)
+      db.execute("CREATE TABLE foo (bar boolean);")
+      db.execute("INSERT INTO foo VALUES('0')")
+      rows = db.execute("SELECT * FROM foo")
+      assert_equal([[false]], rows)
+    end
   end
 end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -365,7 +365,7 @@ module SQLite3
     end
 
     def test_boolean_type_translation
-      db = SQLite3::Database.new(':memory:', type_translation: true)
+      db = SQLite3::Database.new(':memory:', :type_translation => true)
       db.execute("CREATE TABLE foo (bar boolean);")
       db.execute("INSERT INTO foo VALUES('0')")
       rows = db.execute("SELECT * FROM foo")


### PR DESCRIPTION
Without this small fix if you try to read in a boolean that is stored
as "0" or "1" from the database you will get an error like:
undefined method `strip' for 1:Fixnum
