### PR TITLE
Now using SQLite3 3.8.5 for Windows builds

### DIFF
--- a/tasks/native.rake
+++ b/tasks/native.rake
@@ -5,9 +5,9 @@ require 'rake/extensioncompiler'
 # NOTE: version used by cross compilation of Windows native extension
 # It do not affect compilation under other operating systems
 # The version indicated is the minimum DLL suggested for correct functionality
-BINARY_VERSION = "3.7.17"
-URL_VERSION    = "3071700"
-URL_PATH       = "/2013"
+BINARY_VERSION = "3.8.5"
+URL_VERSION    = "3080500"
+URL_PATH       = "/2014"
 
 # build sqlite3_native C extension
 RUBY_EXTENSION = Rake::ExtensionTask.new('sqlite3_native', HOE.spec) do |ext|


### PR DESCRIPTION
I've updated the version information to 3.8.5 and confirmed that it's correct. I can't, however, confirm that installing the gem will work now because I have no idea how to test this. I'm assuming I need to cross compile and I wouldn't know where to start.

Issue: https://github.com/sparklemotion/sqlite3-ruby/issues/134
