### PR TITLE
Add Database#threadsafe? to return true when SQLITE_THREADSAFE is 1 or 2

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -533,6 +533,13 @@ Support for this will be removed in version 2.0.0.
       @readonly
     end
 
+    # Returns +true+ if SQLite3 was compiled with threadsafe mode enabled to
+    # SQLITE_CONFIG_MULTITHREAD or SQLITE_CONFIG_SERIALIZED
+    def threadsafe?
+      option = execute("PRAGMA compile_options").find { |r| r[0] =~ /THREADSAFE/ }[0]
+      ["THREADSAFE=1", "THREADSAFE=2"].include? option
+    end
+
     # A helper class for dealing with custom functions (see #create_function,
     # #create_aggregate, and #create_aggregate_handler). It encapsulates the
     # opaque function object that represents the current invocation. It also

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -363,5 +363,12 @@ module SQLite3
     def test_execute_with_named_bind_params
       assert_equal [['foo']], @db.execute("select :n", {'n' => 'foo'})
     end
+
+    def test_threadsafe_mode
+      assert [true, false].include?(@db.threadsafe?)
+      @db.stub("execute", [["THREADSAFE=0"]]) { assert !@db.threadsafe? }
+      @db.stub("execute", [["THREADSAFE=1"]]) { assert @db.threadsafe? }
+      @db.stub("execute", [["THREADSAFE=2"]]) { assert @db.threadsafe? }
+    end
   end
 end


### PR DESCRIPTION
My application depends on SQLite being threadsafe. I think checking for compiler flags is too low-level, so I thought it would be useful to have this on this gem.
