### PR TITLE
return symbolized keys when using results_as_hash

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -582,8 +582,9 @@ Support for this will be removed in version 2.0.0.
     private
 
     def ordered_map_for columns, row
-      h = Hash[*columns.zip(row).flatten]
-      row.each_with_index { |r, i| h[i] = r }
+      h = Hash.new
+      columns.zip(row) {|k, v| h[k.to_sym] = v}
+      row.each_with_index {|r, i| h[i] = r}
       h
     end
   end


### PR DESCRIPTION
- remove superfluous work when zipping  column
  headers and row data

Addresses #154 and #155 

Also, what purpose does inserting numbered keys serve? Just wondering because commenting it out in benchmarks makes a huge difference.

``` ruby

def ordered_map_for columns, row
  h = Hash[*columns.zip(row).flatten]
  row.each_with_index { |r, i| h[i] = r }
  h
end

def ordered_map_for2 columns, row
  Hash[columns.zip(row)]
end


require 'benchmark'

columns = %w(a b c d e f g h i j k l m n o p q r s)
row     = %w(1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9)

n = 500000
Benchmark.bm do |x|
  x.report("old ") { n.times do ; ordered_map_for columns, row;  end }
  x.report("new ") { n.times do ; ordered_map_for2 columns, row; end }
end

###########
       user     system      total        real
old  14.130000   0.240000  14.370000 ( 14.622877)
new   6.270000   0.060000   6.330000 (  6.445046)
[Finished in 21.2s]
```
