### PR TITLE
Make use of rake-compiler-dock for building windows binary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "mini_portile", "~>0.6.1", :group => [:development, :test]
 gem "minitest", "~>5.4", :group => [:development, :test]
 gem "hoe-bundler", "~>1.0", :group => [:development, :test]
 gem "rake-compiler", "~>0.9.3", :group => [:development, :test]
+gem "rake-compiler-dock", "~>0.4.3", :group => [:development, :test]
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe", "~>3.12", :group => [:development, :test]
 

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -25,6 +25,7 @@ HOE = Hoe.spec 'sqlite3' do
   spec_extras[:extensions] = ["ext/sqlite3/extconf.rb"]
 
   extra_dev_deps << ['rake-compiler', "~> 0.9.3"]
+  extra_dev_deps << ['rake-compiler-dock', "~> 0.4.3"]
   extra_dev_deps << ["mini_portile", "~> 0.6.1"]
   extra_dev_deps << ["minitest", "~> 5.0"]
   extra_dev_deps << ["hoe-bundler", "~> 1.0"]

--- a/tasks/native.rake
+++ b/tasks/native.rake
@@ -5,9 +5,9 @@ require 'rake/extensioncompiler'
 # NOTE: version used by cross compilation of Windows native extension
 # It do not affect compilation under other operating systems
 # The version indicated is the minimum DLL suggested for correct functionality
-BINARY_VERSION = "3.8.6"
-URL_VERSION    = "3080600"
-URL_PATH       = "/2014"
+BINARY_VERSION = "3.8.10.2"
+URL_VERSION    = "3081002"
+URL_PATH       = "/2015"
 
 task :devkit do
   begin

--- a/tasks/vendor_sqlite3.rake
+++ b/tasks/vendor_sqlite3.rake
@@ -89,3 +89,9 @@ task :cross do
     ENV.delete(var)
   end
 end
+
+desc "Build windows binary gems per rake-compiler-dock."
+task "gem:windows" do
+  require "rake_compiler_dock"
+  RakeCompilerDock.sh "bundle && rake cross native gem MAKE='nice make -j`nproc`'"
+end


### PR DESCRIPTION
[rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock) is the successor of the [rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box) - at least in my little universe :smile:
No really - it builds gems faster, with little to no setup and is easy to integrate. A simple 'rake gem:windows' usually does everything.

I tested 'rake gem:windows' on Ubuntu and Windows-7 successfully. I also tested the resulting gems on RubyInstaller versions 2.1.4-x64, 2.2.1-x86 and 2.2.1-x64 on Windows-7 with the test suite and got no failures. OS-X is currently untested.

This PR also updates the sqlite version, although this is not related to rake-compiler-dock.

<b>Update:</b>
I updated the Gemfile und the link to rake-compiler-dock, which has now moved to the rake-compiler organisation.

The resulting files can be tried here: https://github.com/larskanis/sqlite3-ruby/releases/tag/1.3.11-pr159