### PR TITLE
Align #create_aggregate with #create_aggregate_handler

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -395,6 +395,9 @@ Support for this will be removed in version 2.0.0.
 
         def finalize
           super(@ctx)
+          result = @ctx.result
+          @ctx = FunctionProxy.new
+          result
         end
       })
       proxy.ctx = FunctionProxy.new

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -499,6 +499,10 @@ class TC_Database_Integration < SQLite3::TestCase
 
     value = @db.get_first_value( "select accumulate(a) from foo" )
     assert_equal 6, value
+
+    # calling #get_first_value twice don't add up to the latest result
+    value = @db.get_first_value( "select accumulate(a) from foo" )
+    assert_equal 6, value
   end
 
   def test_create_aggregate_with_block


### PR DESCRIPTION
Two issues are covered by this commit:

  * We make use of the value of `result` to define the value of the
    aggreator. Before that, `finalize` was used and this was not
    respecting the documentation;
  * Each call to `finalize` now resets the aggregator. In the future,
    there could be some kind of callback/DSL to make it configurable.

Commit by:

  * Richard K. Michael <rmichael@edgeofthenet.org>
  * Franck Verrot <franck@verrot.fr>