### PR TITLE
Accept Time objects as bind params

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -282,8 +282,14 @@ static VALUE bind_param(VALUE self, VALUE key, VALUE value)
       status = sqlite3_bind_null(ctx->st, index);
       break;
     default:
-      rb_raise(rb_eRuntimeError, "can't prepare %s",
-          rb_class2name(CLASS_OF(value)));
+      if (CLASS_OF(value) == rb_cTime) {
+        /* convert to String and make a recursive call */
+        VALUE timestr = rb_funcall(value, rb_intern("strftime"), 1,
+          rb_str_new2("%Y-%m-%d %H:%M:%S"));
+        return bind_param(self, key, timestr);
+      } else {
+        rb_raise(rb_eRuntimeError, "can't prepare %s", rb_class2name(CLASS_OF(value)));
+      }
       break;
   }
 

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -27,6 +27,13 @@ module SQLite3
       assert_equal [[0, blob, blob.length, blob.length*2]], @db.execute("SELECT id, hash, length(hash), length(hex(hash)) FROM blobs")
     end
 
+    def test_time
+      @db.execute("CREATE TABLE datetimes ( id INTEGER, dt DATETIME )")
+      time = Time.parse('2015-01-01 12:00:00')
+      @db.execute("INSERT INTO datetimes VALUES (0, ?)", [time])
+      assert_equal [["2015-01-01 12:00:00"]], @db.execute("SELECT dt FROM datetimes")
+    end
+
     def test_get_first_row
       assert_equal [1], @db.get_first_row('SELECT 1')
     end

--- a/test/test_database_readonly.rb
+++ b/test/test_database_readonly.rb
@@ -3,7 +3,7 @@ require 'helper'
 module SQLite3
   class TestDatabaseReadonly < SQLite3::TestCase
     def setup
-      File.unlink 'test-readonly.db' if File.exists?('test-readonly.db')
+      File.unlink 'test-readonly.db' if File.exist?('test-readonly.db')
       @db = SQLite3::Database.new('test-readonly.db')
       @db.execute("CREATE TABLE foos (id integer)")
       @db.close

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -34,7 +34,7 @@ module SQLite3
       #   UNIQUE constraint failed: *table_name*.*column_name*
       # Older versions of SQLite return:
       #   column *column_name* is not unique
-      assert_match /(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/, exception.message
+      assert_match(/(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/, exception.message)
     end
 
     ###

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -119,6 +119,14 @@ module SQLite3
       assert_equal [nil], result
     end
 
+    def test_bind_time
+      stmt = SQLite3::Statement.new(@db, "select ?")
+      stmt.bind_param(1, Time.parse("2000-10-01"))
+      result = nil
+      stmt.each { |x| result = x }
+      assert_equal ['2000-10-01 00:00:00'], result
+    end
+
     def test_bind_blobs
     end
 


### PR DESCRIPTION
SQLite has 'datetime' columns, so it seems natural to pass Time objects in as bind
params when executing a query.

It would also be good to support Date and DateTime objects (from 'datetime' in
stdlib) in the future. These are not built-in Ruby core classes, so there is no
global variable like 'rb_cTime' which can be used to refer to them.