### PR TITLE
Call close in ensure

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -30,6 +30,8 @@ utf16_string_value_ptr(VALUE str)
   return RSTRING_PTR(str);
 }
 
+static VALUE sqlite3_rb_close(VALUE self);
+
 /* call-seq: SQLite3::Database.new(file, options = {})
  *
  * Create a new Database object that opens the given file. If utf16
@@ -120,8 +122,7 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self)
 #endif
 
   if(rb_block_given_p()) {
-    rb_yield(self);
-    rb_funcall(self, rb_intern("close"), 0);
+    rb_ensure(rb_yield, self, sqlite3_rb_close, self);
   }
 
   return self;

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -109,6 +109,18 @@ module SQLite3
       assert thing.closed?
     end
 
+    def test_block_closes_self_even_raised
+      thing = nil
+      begin
+        SQLite3::Database.new(':memory:') do |db|
+          thing = db
+          raise
+        end
+      rescue
+      end
+      assert thing.closed?
+    end
+
     def test_prepare
       db = SQLite3::Database.new(':memory:')
       stmt = db.prepare('select "hello world"')


### PR DESCRIPTION
I seem that `close` method should be called even when given block rises an error.