### PR TITLE
BLOB function result when ASCII-8BIT encoding

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -322,12 +322,21 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
       sqlite3_result_double(ctx, NUM2DBL(result));
       break;
     case T_STRING:
-      sqlite3_result_text(
-          ctx,
-          (const char *)StringValuePtr(result),
-          (int)RSTRING_LEN(result),
-          SQLITE_TRANSIENT
-      );
+      if (rb_enc_get_index(result) == rb_ascii8bit_encindex()) {
+        sqlite3_result_blob(
+            ctx,
+            (const void *)StringValuePtr(result),
+            (int)RSTRING_LEN(result),
+            SQLITE_TRANSIENT
+        );
+      } else {
+        sqlite3_result_text(
+            ctx,
+            (const char *)StringValuePtr(result),
+            (int)RSTRING_LEN(result),
+            SQLITE_TRANSIENT
+        );
+      }
       break;
     default:
       rb_raise(rb_eRuntimeError, "can't return %s",

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -322,6 +322,7 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
       sqlite3_result_double(ctx, NUM2DBL(result));
       break;
     case T_STRING:
+#ifdef HAVE_RUBY_ENCODING_H
       if (rb_enc_get_index(result) == rb_ascii8bit_encindex()) {
         sqlite3_result_blob(
             ctx,
@@ -330,13 +331,16 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
             SQLITE_TRANSIENT
         );
       } else {
+#endif
         sqlite3_result_text(
             ctx,
             (const char *)StringValuePtr(result),
             (int)RSTRING_LEN(result),
             SQLITE_TRANSIENT
         );
+#ifdef HAVE_RUBY_ENCODING_H
       }
+#endif
       break;
     default:
       rb_raise(rb_eRuntimeError, "can't return %s",

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -322,8 +322,11 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
       sqlite3_result_double(ctx, NUM2DBL(result));
       break;
     case T_STRING:
+      if(CLASS_OF(result) == cSqlite3Blob
 #ifdef HAVE_RUBY_ENCODING_H
-      if (rb_enc_get_index(result) == rb_ascii8bit_encindex()) {
+              || rb_enc_get_index(result) == rb_ascii8bit_encindex()
+#endif
+        ) {
         sqlite3_result_blob(
             ctx,
             (const void *)StringValuePtr(result),
@@ -331,16 +334,13 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
             SQLITE_TRANSIENT
         );
       } else {
-#endif
         sqlite3_result_text(
             ctx,
             (const char *)StringValuePtr(result),
             (int)RSTRING_LEN(result),
             SQLITE_TRANSIENT
         );
-#ifdef HAVE_RUBY_ENCODING_H
       }
-#endif
       break;
     default:
       rb_raise(rb_eRuntimeError, "can't return %s",

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -288,7 +288,14 @@ static VALUE sqlite3val2rb(sqlite3_value * val)
          which is what we want, as blobs are binary
        */
       int len = sqlite3_value_bytes(val);
+#ifdef HAVE_RUBY_ENCODING_H
       return rb_tainted_str_new((const char *)sqlite3_value_blob(val), len);
+#else
+      /* When encoding is not available, make it class SQLite3::Blob. */
+      VALUE strargv[1];
+      strargv[0] = rb_tainted_str_new((const char *)sqlite3_value_blob(val), len);
+      return rb_class_new_instance(1, strargv, cSqlite3Blob);
+#endif
       break;
     }
     case SQLITE_NULL:

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -269,7 +269,7 @@ module SQLite3
 
     def test_function_return_type_round_trip
       [10, 2.2, nil, "foo", Blob.new("foo\0bar")].each do |thing|
-        @db.define_function("hello") { |thing| thing }
+        @db.define_function("hello") { |a| a }
         assert_equal [thing], @db.execute("select hello(hello(?))", [thing]).first
       end
     end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -261,9 +261,16 @@ module SQLite3
     end
 
     def test_function_return_types
-      [10, 2.2, nil, "foo"].each do |thing|
+      [10, 2.2, nil, "foo", Blob.new("foo\0bar")].each do |thing|
         @db.define_function("hello") { |a| thing }
         assert_equal [thing], @db.execute("select hello('world')").first
+      end
+    end
+
+    def test_function_return_type_round_trip
+      [10, 2.2, nil, "foo", Blob.new("foo\0bar")].each do |thing|
+        @db.define_function("hello") { |thing| thing }
+        assert_equal [thing], @db.execute("select hello(hello(?))", [thing]).first
       end
     end
 


### PR DESCRIPTION
Hello,
I was unable to return BLOB values from created functions using the gem. The change in this pull request allows returning of a BLOB value from a created function.

If the encoding on the string value is ASCII-8BIT, then the return value is a BLOB instead of TEXT. This is important if binary data contains null values, or is otherwise not valid UTF-8.