### PR TITLE
Keep arg values on stack to prevent segfault in user-created function

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -359,22 +359,17 @@ static void set_sqlite3_func_result(sqlite3_context * ctx, VALUE result)
 static void rb_sqlite3_func(sqlite3_context * ctx, int argc, sqlite3_value **argv)
 {
   VALUE callable = (VALUE)sqlite3_user_data(ctx);
-  VALUE * params = NULL;
+  VALUE params[argc]; /* RB_GC_GUARD unreliable -- keep values safely on the stack */
   VALUE result;
   int i;
 
   if (argc > 0) {
-    params = xcalloc((size_t)argc, sizeof(VALUE *));
-
     for(i = 0; i < argc; i++) {
-      VALUE param = sqlite3val2rb(argv[i]);
-      RB_GC_GUARD(param);
-      params[i] = param;
+      params[i] = sqlite3val2rb(argv[i]);
     }
   }
 
   result = rb_funcall2(callable, rb_intern("call"), argc, params);
-  xfree(params);
 
   set_sqlite3_func_result(ctx, result);
 }

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -279,6 +279,15 @@ module SQLite3
       end
     end
 
+    def test_function_gc_segfault
+      skip("Segfault is unsettling to see when running rake test")
+      @db.create_function("bug", -1) { |func, *values| func.result = values.join }
+      # With a lot of data and a lot of threads, try to induce a GC segfault.
+      params = Array.new(127, "?" * 28000)
+      proc = Proc.new { db.execute("select bug(#{Array.new(params.length, "?").join(",")})", *params) }
+      Mutex.new.tap { |m| threads = (0..30).inject([]) { |a| a << Thread.new { m.synchronize { proc.call } } }.each { |thread| thread.join } }
+    end
+
     def test_function_return_type_round_trip
       [10, 2.2, nil, "foo", Blob.new("foo\0bar")].each do |thing|
         @db.define_function("hello") { |a| a }


### PR DESCRIPTION
I do not know a lot about Ruby garbage collection internals and the use of RB_GC_GUARD, but certainly from what I've found, keeping VALUE on the stack prevents premature collection.

I can easily cause a segfault by creating a user-defined function that itself creates Ruby objects while doing its work. This fix seems to alleviate the segfaults, and I think it's because this directly puts the VALUE pointers on the stack, where garbage collection cannot miss them.