### PR TITLE
SafeDatabase class that checks the DB existence on the filesystem

### DIFF
--- a/lib/sqlite3/errors.rb
+++ b/lib/sqlite3/errors.rb
@@ -41,4 +41,5 @@ module SQLite3
   class FormatException < Exception; end
   class RangeException < Exception; end
   class NotADatabaseException < Exception; end
+  class DatabaseNotFound < Exception; end
 end

--- a/lib/sqlite3/safe_database.rb
+++ b/lib/sqlite3/safe_database.rb
@@ -1,0 +1,46 @@
+require 'sqlite3/database'
+
+module SQLite3
+  class SafeDatabase < SQLite3::Database
+
+    def self.open(path)
+      raise SQLite3::DatabaseNotFound, "Could not find database at #{path}" unless File.exist?(path)
+      self.new(path)
+    end
+
+    def initialize(path)
+      @path = path
+      super(path)
+    end
+
+    def exist?
+      File.exist?(@path)
+    end
+
+    def exist!
+      raise SQLite3::DatabaseNotFound, "Could not find database at #{@path}" unless exist?
+      true
+    end
+
+    def execute(sql, bind_vars = [], *args, &block)
+      exist!
+      super(sql, bind_vars, *args, &block)
+    end
+
+    def execute2( sql, *bind_vars )
+      exist!
+      super(sql, *bind_vars)
+    end
+
+    def execute_batch( sql, bind_vars = [], *args )
+      exist!
+      super(sql, bind_vars, *args)
+    end
+
+    def query( sql, bind_vars = [], *args )
+      exist!
+      super(sql, bind_vars, *args)
+    end
+
+  end
+end

--- a/lib/sqlite3/safe_database.rb
+++ b/lib/sqlite3/safe_database.rb
@@ -3,6 +3,8 @@ require 'sqlite3/database'
 module SQLite3
   class SafeDatabase < SQLite3::Database
 
+    attr_reader :path
+
     def self.open(path)
       raise SQLite3::DatabaseNotFound, "Could not find database at #{path}" unless File.exist?(path)
       self.new(path)


### PR DESCRIPTION
It has the same API as `SQLite3::Database` but `#new` and `#open` mean different things now:

* `#new` causes the database to be created, skipping the existence check
* `#open` causes the database path to be checked, raising a `SQLite3::DatabaseNotFound` exception if it doesn't exist

Before the following methods pass to `super` the check is done:

* `.execute`
* `.execute2`
* `.execute_batch`
* `.query`

Should fix the phantom disk usage bug identified in #173 