### PR TITLE
add 'readwrite' flag to Database.new options for readwrite without cr…

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -73,6 +73,42 @@ static VALUE threadsafe_p(VALUE UNUSED(klass))
   return INT2NUM(sqlite3_threadsafe());
 }
 
+void init_sqlite3_constants()
+{
+  VALUE mSqlite3Constants;
+  VALUE mSqlite3Open;
+
+  mSqlite3Constants = rb_define_module_under(mSqlite3, "Constants");
+
+  /* sqlite3_open_v2 flags for Database::new */
+  mSqlite3Open = rb_define_module_under(mSqlite3Constants, "Open");
+
+  /* symbols = IO.readlines('sqlite3.h').map { |n| /\A#define\s+(SQLITE_OPEN_\w+)\s/ =~ n && $1 }.compact
+   * pad = symbols.map(&:length).max - 9
+   * symbols.each { |s| printf %Q{  rb_define_const(mSqlite3Open, %-#{pad}s INT2FIX(#{s}));\n}, '"' + s[12..-1] + '",' }
+   */
+  rb_define_const(mSqlite3Open, "READONLY",       INT2FIX(SQLITE_OPEN_READONLY));
+  rb_define_const(mSqlite3Open, "READWRITE",      INT2FIX(SQLITE_OPEN_READWRITE));
+  rb_define_const(mSqlite3Open, "CREATE",         INT2FIX(SQLITE_OPEN_CREATE));
+  rb_define_const(mSqlite3Open, "DELETEONCLOSE",  INT2FIX(SQLITE_OPEN_DELETEONCLOSE));
+  rb_define_const(mSqlite3Open, "EXCLUSIVE",      INT2FIX(SQLITE_OPEN_EXCLUSIVE));
+  rb_define_const(mSqlite3Open, "AUTOPROXY",      INT2FIX(SQLITE_OPEN_AUTOPROXY));
+  rb_define_const(mSqlite3Open, "URI",            INT2FIX(SQLITE_OPEN_URI));
+  rb_define_const(mSqlite3Open, "MEMORY",         INT2FIX(SQLITE_OPEN_MEMORY));
+  rb_define_const(mSqlite3Open, "MAIN_DB",        INT2FIX(SQLITE_OPEN_MAIN_DB));
+  rb_define_const(mSqlite3Open, "TEMP_DB",        INT2FIX(SQLITE_OPEN_TEMP_DB));
+  rb_define_const(mSqlite3Open, "TRANSIENT_DB",   INT2FIX(SQLITE_OPEN_TRANSIENT_DB));
+  rb_define_const(mSqlite3Open, "MAIN_JOURNAL",   INT2FIX(SQLITE_OPEN_MAIN_JOURNAL));
+  rb_define_const(mSqlite3Open, "TEMP_JOURNAL",   INT2FIX(SQLITE_OPEN_TEMP_JOURNAL));
+  rb_define_const(mSqlite3Open, "SUBJOURNAL",     INT2FIX(SQLITE_OPEN_SUBJOURNAL));
+  rb_define_const(mSqlite3Open, "MASTER_JOURNAL", INT2FIX(SQLITE_OPEN_MASTER_JOURNAL));
+  rb_define_const(mSqlite3Open, "NOMUTEX",        INT2FIX(SQLITE_OPEN_NOMUTEX));
+  rb_define_const(mSqlite3Open, "FULLMUTEX",      INT2FIX(SQLITE_OPEN_FULLMUTEX));
+  rb_define_const(mSqlite3Open, "SHAREDCACHE",    INT2FIX(SQLITE_OPEN_SHAREDCACHE));
+  rb_define_const(mSqlite3Open, "PRIVATECACHE",   INT2FIX(SQLITE_OPEN_PRIVATECACHE));
+  rb_define_const(mSqlite3Open, "WAL",            INT2FIX(SQLITE_OPEN_WAL));
+}
+
 void Init_sqlite3_native()
 {
   /*
@@ -93,6 +129,7 @@ void Init_sqlite3_native()
   sqlite3_initialize();
 #endif
 
+  init_sqlite3_constants();
   init_sqlite3_database();
   init_sqlite3_statement();
 #ifdef HAVE_SQLITE3_BACKUP_INIT

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -15,6 +15,7 @@ module SQLite3
     end
 
     def test_db_filename
+      tf = nil
       assert_equal '', @db.filename('main')
       tf = Tempfile.new 'thing'
       @db = SQLite3::Database.new tf.path
@@ -24,6 +25,7 @@ module SQLite3
     end
 
     def test_filename
+      tf = nil
       assert_equal '', @db.filename
       tf = Tempfile.new 'thing'
       @db = SQLite3::Database.new tf.path
@@ -33,6 +35,7 @@ module SQLite3
     end
 
     def test_filename_with_attachment
+      tf = nil
       assert_equal '', @db.filename
       tf = Tempfile.new 'thing'
       @db.execute "ATTACH DATABASE '#{tf.path}' AS 'testing'"

--- a/test/test_database_flags.rb
+++ b/test/test_database_flags.rb
@@ -1,0 +1,88 @@
+require 'helper'
+
+module SQLite3
+  class TestDatabaseFlags < SQLite3::TestCase
+    def setup
+      File.unlink 'test-flags.db' if File.exists?('test-flags.db')
+      @db = SQLite3::Database.new('test-flags.db')
+      @db.execute("CREATE TABLE foos (id integer)")
+      @db.close
+    end
+
+    def teardown
+      @db.close unless @db.closed?
+      File.unlink 'test-flags.db' if File.exists?('test-flags.db')
+    end
+
+    def test_open_database_flags_constants
+      defined_to_date = [:READONLY, :READWRITE, :CREATE,
+                         :DELETEONCLOSE, :EXCLUSIVE, :AUTOPROXY, :URI, :MEMORY,
+                         :MAIN_DB, :TEMP_DB, :TRANSIENT_DB,
+                         :MAIN_JOURNAL, :TEMP_JOURNAL, :SUBJOURNAL, :MASTER_JOURNAL,
+                         :NOMUTEX, :FULLMUTEX,
+                         :SHAREDCACHE, :PRIVATECACHE, :WAL]
+      assert (defined_to_date - SQLite3::Constants::Open.constants).empty?
+    end
+
+    def test_open_database_flags_conflicts_with_readonly
+      assert_raise(RuntimeError) do
+        @db = SQLite3::Database.new('test-flags.db', :flags => 2, :readonly => true)
+      end
+    end
+
+    def test_open_database_flags_conflicts_with_readwrite
+      assert_raise(RuntimeError) do
+        @db = SQLite3::Database.new('test-flags.db', :flags => 2, :readwrite => true)
+      end
+    end
+
+    def test_open_database_readonly_flags
+      @db = SQLite3::Database.new('test-flags.db', :flags => SQLite3::Constants::Open::READONLY)
+      assert @db.readonly?
+    end
+
+    def test_open_database_readwrite_flags
+      @db = SQLite3::Database.new('test-flags.db', :flags => SQLite3::Constants::Open::READWRITE)
+      assert !@db.readonly?
+    end
+
+    def test_open_database_readonly_flags_cant_open
+      File.unlink 'test-flags.db'
+      assert_raise(SQLite3::CantOpenException) do
+        @db = SQLite3::Database.new('test-flags.db', :flags => SQLite3::Constants::Open::READONLY)
+      end
+    end
+
+    def test_open_database_readwrite_flags_cant_open
+      File.unlink 'test-flags.db'
+      assert_raise(SQLite3::CantOpenException) do
+        @db = SQLite3::Database.new('test-flags.db', :flags => SQLite3::Constants::Open::READWRITE)
+      end
+    end
+
+    def test_open_database_misuse_flags
+      assert_raise(SQLite3::MisuseException) do
+        flags = SQLite3::Constants::Open::READONLY | SQLite3::Constants::Open::READWRITE # <== incompatible flags
+        @db = SQLite3::Database.new('test-flags.db', :flags => flags)
+      end
+    end
+
+    def test_open_database_create_flags
+      File.unlink 'test-flags.db'
+      flags = SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
+      @db = SQLite3::Database.new('test-flags.db', :flags => flags) do |db|
+        db.execute("CREATE TABLE foos (id integer)")
+        db.execute("INSERT INTO foos (id) VALUES (12)")
+      end
+      assert File.exists?('test-flags.db')
+    end
+
+    def test_open_database_exotic_flags
+      flags = SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
+      exotic_flags = SQLite3::Constants::Open::NOMUTEX | SQLite3::Constants::Open::PRIVATECACHE
+      @db = SQLite3::Database.new('test-flags.db', :flags => flags | exotic_flags)
+      @db.execute("INSERT INTO foos (id) VALUES (12)")
+      assert @db.changes == 1
+    end
+  end
+end

--- a/test/test_database_readonly.rb
+++ b/test/test_database_readonly.rb
@@ -11,12 +11,19 @@ module SQLite3
 
     def teardown
       @db.close unless @db.closed?
-      File.unlink 'test-readonly.db'
+      File.unlink 'test-readonly.db' if File.exists?('test-readonly.db')
     end
 
     def test_open_readonly_database
       @db = SQLite3::Database.new('test-readonly.db', :readonly => true)
       assert @db.readonly?
+    end
+
+    def test_open_readonly_not_exists_database
+      File.unlink 'test-readonly.db'
+      assert_raise(SQLite3::CantOpenException) do
+        @db = SQLite3::Database.new('test-readonly.db', :readonly => true)
+      end
     end
 
     def test_insert_readonly_database

--- a/test/test_database_readwrite.rb
+++ b/test/test_database_readwrite.rb
@@ -1,0 +1,41 @@
+require 'helper'
+
+module SQLite3
+  class TestDatabaseReadwrite < SQLite3::TestCase
+    def setup
+      File.unlink 'test-readwrite.db' if File.exists?('test-readwrite.db')
+      @db = SQLite3::Database.new('test-readwrite.db')
+      @db.execute("CREATE TABLE foos (id integer)")
+      @db.close
+    end
+
+    def teardown
+      @db.close unless @db.closed?
+      File.unlink 'test-readwrite.db' if File.exists?('test-readwrite.db')
+    end
+
+    def test_open_readwrite_database
+      @db = SQLite3::Database.new('test-readwrite.db', :readwrite => true)
+      assert !@db.readonly?
+    end
+
+    def test_open_readwrite_readonly_database
+      assert_raise(RuntimeError) do
+        @db = SQLite3::Database.new('test-readwrite.db', :readwrite => true, :readonly => true)
+      end
+    end
+
+    def test_open_readwrite_not_exists_database
+      File.unlink 'test-readwrite.db'
+      assert_raise(SQLite3::CantOpenException) do
+        @db = SQLite3::Database.new('test-readwrite.db', :readonly => true)
+      end
+    end
+
+    def test_insert_readwrite_database
+      @db = SQLite3::Database.new('test-readwrite.db', :readwrite => true)
+      @db.execute("INSERT INTO foos (id) VALUES (12)")
+      assert @db.changes == 1
+    end
+  end
+end


### PR DESCRIPTION
…eate

The SQLite3 [doc page](https://www.sqlite.org/c3ref/open.html) for `sqlite_open`, `sqlite_open16`, and `sqlite3_open_v2` reads, "The flags parameter to sqlite3_open_v2() can take one of the _following three values_ [emphasis added], optionally combined with..."

Those three values are:

```
SQLITE_OPEN_READONLY
SQLITE_OPEN_READWRITE
SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE

```

This change preserves the prior behavior of the gem, to use `SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE` unless otherwise specified, and to use `SQLITE_OPEN_READONLY` if `{ :readonly => true }`, and adds a new option, `readwrite`, to cover the third SQLite3 value, which is open for read/write without create. I think this best fits the character of sqlite3_open_v2 and the simplicity of the gem's interface.

The `{ :readwrite => true }` lets you gracefully rescue an `SQLite3::CantOpenException` similar to what you can do with today with `{ :readonly => true }`.