### PR TITLE
SQLITE_VERSION_NUMBER #ifdefs surrounding sqlite3_open_v2 constants

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -92,9 +92,6 @@ void init_sqlite3_constants()
   rb_define_const(mSqlite3Open, "CREATE",         INT2FIX(SQLITE_OPEN_CREATE));
   rb_define_const(mSqlite3Open, "DELETEONCLOSE",  INT2FIX(SQLITE_OPEN_DELETEONCLOSE));
   rb_define_const(mSqlite3Open, "EXCLUSIVE",      INT2FIX(SQLITE_OPEN_EXCLUSIVE));
-  rb_define_const(mSqlite3Open, "AUTOPROXY",      INT2FIX(SQLITE_OPEN_AUTOPROXY));
-  rb_define_const(mSqlite3Open, "URI",            INT2FIX(SQLITE_OPEN_URI));
-  rb_define_const(mSqlite3Open, "MEMORY",         INT2FIX(SQLITE_OPEN_MEMORY));
   rb_define_const(mSqlite3Open, "MAIN_DB",        INT2FIX(SQLITE_OPEN_MAIN_DB));
   rb_define_const(mSqlite3Open, "TEMP_DB",        INT2FIX(SQLITE_OPEN_TEMP_DB));
   rb_define_const(mSqlite3Open, "TRANSIENT_DB",   INT2FIX(SQLITE_OPEN_TRANSIENT_DB));
@@ -104,9 +101,21 @@ void init_sqlite3_constants()
   rb_define_const(mSqlite3Open, "MASTER_JOURNAL", INT2FIX(SQLITE_OPEN_MASTER_JOURNAL));
   rb_define_const(mSqlite3Open, "NOMUTEX",        INT2FIX(SQLITE_OPEN_NOMUTEX));
   rb_define_const(mSqlite3Open, "FULLMUTEX",      INT2FIX(SQLITE_OPEN_FULLMUTEX));
+#ifdef SQLITE_OPEN_AUTOPROXY
+  /* SQLITE_VERSION_NUMBER>=3007002 */
+  rb_define_const(mSqlite3Open, "AUTOPROXY",      INT2FIX(SQLITE_OPEN_AUTOPROXY));
   rb_define_const(mSqlite3Open, "SHAREDCACHE",    INT2FIX(SQLITE_OPEN_SHAREDCACHE));
   rb_define_const(mSqlite3Open, "PRIVATECACHE",   INT2FIX(SQLITE_OPEN_PRIVATECACHE));
   rb_define_const(mSqlite3Open, "WAL",            INT2FIX(SQLITE_OPEN_WAL));
+#endif
+#ifdef SQLITE_OPEN_URI
+  /* SQLITE_VERSION_NUMBER>=3007007 */
+  rb_define_const(mSqlite3Open, "URI",            INT2FIX(SQLITE_OPEN_URI));
+#endif
+#ifdef SQLITE_OPEN_MEMORY
+  /* SQLITE_VERSION_NUMBER>=3007013 */
+  rb_define_const(mSqlite3Open, "MEMORY",         INT2FIX(SQLITE_OPEN_MEMORY));
+#endif
 }
 
 void Init_sqlite3_native()

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -319,7 +319,7 @@ module SQLite3
         db.execute("select bug(#{Array.new(params.length, "?").join(",")})", params)
       }
       m = Mutex.new
-      threads = 30.times.map { Thread.new { m.synchronize { proc.call } } }.each(&:join)
+      30.times.map { Thread.new { m.synchronize { proc.call } } }.each(&:join)
     end
 
     def test_function_return_type_round_trip

--- a/test/test_database_flags.rb
+++ b/test/test_database_flags.rb
@@ -3,7 +3,7 @@ require 'helper'
 module SQLite3
   class TestDatabaseFlags < SQLite3::TestCase
     def setup
-      File.unlink 'test-flags.db' if File.exists?('test-flags.db')
+      File.unlink 'test-flags.db' if File.exist?('test-flags.db')
       @db = SQLite3::Database.new('test-flags.db')
       @db.execute("CREATE TABLE foos (id integer)")
       @db.close
@@ -11,7 +11,7 @@ module SQLite3
 
     def teardown
       @db.close unless @db.closed?
-      File.unlink 'test-flags.db' if File.exists?('test-flags.db')
+      File.unlink 'test-flags.db' if File.exist?('test-flags.db')
     end
 
     def test_open_database_flags_constants
@@ -28,7 +28,7 @@ module SQLite3
       if SQLite3::SQLITE_VERSION_NUMBER > 3007013
         defined_to_date += [:MEMORY]
       end
-      assert (defined_to_date - SQLite3::Constants::Open.constants).empty?
+      assert defined_to_date.sort == SQLite3::Constants::Open.constants.sort
     end
 
     def test_open_database_flags_conflicts_with_readonly
@@ -81,7 +81,7 @@ module SQLite3
         db.execute("CREATE TABLE foos (id integer)")
         db.execute("INSERT INTO foos (id) VALUES (12)")
       end
-      assert File.exists?('test-flags.db')
+      assert File.exist?('test-flags.db')
     end
 
     def test_open_database_exotic_flags

--- a/test/test_database_flags.rb
+++ b/test/test_database_flags.rb
@@ -15,12 +15,19 @@ module SQLite3
     end
 
     def test_open_database_flags_constants
-      defined_to_date = [:READONLY, :READWRITE, :CREATE,
-                         :DELETEONCLOSE, :EXCLUSIVE, :AUTOPROXY, :URI, :MEMORY,
-                         :MAIN_DB, :TEMP_DB, :TRANSIENT_DB,
-                         :MAIN_JOURNAL, :TEMP_JOURNAL, :SUBJOURNAL, :MASTER_JOURNAL,
-                         :NOMUTEX, :FULLMUTEX,
-                         :SHAREDCACHE, :PRIVATECACHE, :WAL]
+      defined_to_date = [:READONLY, :READWRITE, :CREATE, :DELETEONCLOSE,
+                         :EXCLUSIVE, :MAIN_DB, :TEMP_DB, :TRANSIENT_DB,
+                         :MAIN_JOURNAL, :TEMP_JOURNAL, :SUBJOURNAL,
+                         :MASTER_JOURNAL, :NOMUTEX, :FULLMUTEX]
+      if SQLite3::SQLITE_VERSION_NUMBER > 3007002
+        defined_to_date += [:AUTOPROXY, :SHAREDCACHE, :PRIVATECACHE, :WAL]
+      end
+      if SQLite3::SQLITE_VERSION_NUMBER > 3007007
+        defined_to_date += [:URI]
+      end
+      if SQLite3::SQLITE_VERSION_NUMBER > 3007013
+        defined_to_date += [:MEMORY]
+      end
       assert (defined_to_date - SQLite3::Constants::Open.constants).empty?
     end
 
@@ -79,7 +86,7 @@ module SQLite3
 
     def test_open_database_exotic_flags
       flags = SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
-      exotic_flags = SQLite3::Constants::Open::NOMUTEX | SQLite3::Constants::Open::PRIVATECACHE
+      exotic_flags = SQLite3::Constants::Open::NOMUTEX | SQLite3::Constants::Open::TEMP_DB
       @db = SQLite3::Database.new('test-flags.db', :flags => flags | exotic_flags)
       @db.execute("INSERT INTO foos (id) VALUES (12)")
       assert @db.changes == 1

--- a/test/test_database_readonly.rb
+++ b/test/test_database_readonly.rb
@@ -3,7 +3,7 @@ require 'helper'
 module SQLite3
   class TestDatabaseReadonly < SQLite3::TestCase
     def setup
-      File.unlink 'test-readonly.db' if File.exists?('test-readonly.db')
+      File.unlink 'test-readonly.db' if File.exist?('test-readonly.db')
       @db = SQLite3::Database.new('test-readonly.db')
       @db.execute("CREATE TABLE foos (id integer)")
       @db.close
@@ -11,7 +11,7 @@ module SQLite3
 
     def teardown
       @db.close unless @db.closed?
-      File.unlink 'test-readonly.db' if File.exists?('test-readonly.db')
+      File.unlink 'test-readonly.db' if File.exist?('test-readonly.db')
     end
 
     def test_open_readonly_database

--- a/test/test_database_readwrite.rb
+++ b/test/test_database_readwrite.rb
@@ -3,7 +3,7 @@ require 'helper'
 module SQLite3
   class TestDatabaseReadwrite < SQLite3::TestCase
     def setup
-      File.unlink 'test-readwrite.db' if File.exists?('test-readwrite.db')
+      File.unlink 'test-readwrite.db' if File.exist?('test-readwrite.db')
       @db = SQLite3::Database.new('test-readwrite.db')
       @db.execute("CREATE TABLE foos (id integer)")
       @db.close
@@ -11,7 +11,7 @@ module SQLite3
 
     def teardown
       @db.close unless @db.closed?
-      File.unlink 'test-readwrite.db' if File.exists?('test-readwrite.db')
+      File.unlink 'test-readwrite.db' if File.exist?('test-readwrite.db')
     end
 
     def test_open_readwrite_database


### PR DESCRIPTION
This adds #ifdefs around the C constants for the sqlite3_open_v2 flags. I pulled tarballs from https://www.sqlite.org/src/taglist and built each sqlite3.h until I found the version where each constant first appears.