### PR TITLE
Track names of fns created on db instance

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -337,11 +337,19 @@ Support for this will be removed in version 2.0.0.
       self
     end
 
+    # Returns an array of the names of all functions that have been created on
+    # the target instance using #create_function.
     def created_function_names
       @created_function_names ||= []
       @created_function_names.dup
     end
 
+    # Returns true if a function with the given name (case insensitive) has been
+    # created on the target instance using #create_function.
+    #
+    # After creating a function named "mIxEd_CaSe", for instance, both
+    # `function_created?("mixed_case")` and `function_created?("MIXED_CASE")`
+    # will return `true`.
     def function_created?(name)
       key = name.downcase
       created_function_keys.include?(key)

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'sqlite3/constants'
 require 'sqlite3/errors'
 require 'sqlite3/pragmas'
@@ -331,8 +332,25 @@ Support for this will be removed in version 2.0.0.
         block.call(fp, *args)
         fp.result
       end
+      ( @created_function_names ||= [] ) << name
+      created_function_keys << name.downcase
       self
     end
+
+    def created_function_names
+      @created_function_names ||= []
+      @created_function_names.dup
+    end
+
+    def function_created?(name)
+      key = name.downcase
+      created_function_keys.include?(key)
+    end
+
+    def created_function_keys
+      @created_function_keys ||= Set.new
+    end
+    private :created_function_keys
 
     # Creates a new aggregate function for use in SQL statements. Aggregate
     # functions are functions that apply over every row in the result set,

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -487,6 +487,25 @@ class TC_Database_Integration < SQLite3::TestCase
     assert_match( />>>.*<<</, value )
   end
 
+  def test_track_created_functions
+    @db.create_function( "foo", 0 ) do |*args| ; end
+    @db.create_function( "BAR", 0 ) do |*args| ; end
+
+    assert_includes( @db.created_function_names, "foo" )
+    assert_includes( @db.created_function_names, "BAR" )
+  end
+
+  def test_check_whether_function_created?
+    @db.create_function( "foo", 0 ) do |*args| ; end
+    @db.create_function( "BAR", 0 ) do |*args| ; end
+
+    assert_equal( false, @db.function_created?("baz") )
+
+    assert_equal( true, @db.function_created?("foo") )
+    assert_equal( true, @db.function_created?("FOO") )
+    assert_equal( true, @db.function_created?("bar") )
+  end
+
   def test_create_aggregate_without_block
     step = proc do |ctx,a|
       ctx[:sum] ||= 0


### PR DESCRIPTION
I have found that it useful to be able check whether a function with a particular name has been created on an instance of `SQLite3::Database`. In the sqlite_ext gem, I monkey-patched that into the class, but I think it makes sense to have that as a native capability of the sqlite3 gem.
This PR adds that functionality.
