### PR TITLE
add missing SELECT into example in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,11 @@ Note that this module is only compatible with SQLite 3.6.16 or newer.
     db.execute "insert into numbers values ( ?, ? )", pair
   end
 
+  # Find a few rows
+  db.execute( "select * from numbers" ) do |row|
+    p row
+  end
+
   # Create another table with multiple columns
 
   db.execute <<-SQL
@@ -53,8 +58,7 @@ Note that this module is only compatible with SQLite 3.6.16 or newer.
   db.execute("INSERT INTO students (name, email, grade, blog) 
               VALUES (?, ?, ?, ?)", ["Jane", "me@janedoe.com", "A", "http://blog.janedoe.com"])
   
-  # Find a few rows
-  db.execute( "select * from numbers" ) do |row|
+  db.execute( "select * from students" ) do |row|
     p row
   end
 


### PR DESCRIPTION
I noticed that the example in the README.rdoc has a small issue: It doesn't _select_ the inserted rows from the second table.
I inserted an additional select statement into the example.