### PR TITLE
Use 'brew --prefix' for OS X/macOS compile flags

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -11,10 +11,10 @@ RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 ldflags = cppflags = nil
 if RbConfig::CONFIG["host_os"] =~ /darwin/
   begin
-    brew_info = `brew info sqlite3`
-    ldflags   = brew_info[/LDFLAGS.*$/].split(/-L/).last
-    cppflags  = brew_info[/CPPFLAGS.*$/].split(/-I/).last
-    pkg_conf  = brew_info[/PKG_CONFIG_PATH.*$/].split(": ").last
+    brew_prefix = `brew --prefix sqlite3`
+    ldflags   = "#{brew_prefix}/lib"
+    cppflags  = "#{brew_prefix}/include"
+    pkg_conf  = "#{brew_prefix}/lib/pkgconfig"
 
     # pkg_config should be less error prone than parsing compiler
     # commandline options, but we need to set default ldflags and cpp flags


### PR DESCRIPTION
This is slightly faster and doesn't rely on the format of `brew info`.
