### PR TITLE
Prepare for Minitest 6

### DIFF
--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -386,7 +386,7 @@ module SQLite3
         def call action, a, b, c, d; nil end
       }.new
       stmt = @db.prepare("select 'fooooo'")
-      assert_equal nil, stmt.step
+      assert_nil stmt.step
     end
 
     def test_authorizer_fail

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -216,7 +216,7 @@ module SQLite3
 
     def test_column_name
       assert_equal "'foo'", @stmt.column_name(0)
-      assert_equal nil, @stmt.column_name(10)
+      assert_nil @stmt.column_name(10)
     end
 
     def test_bind_parameter_count


### PR DESCRIPTION
- Use assert_nil if expecting nil, this will fail in MT6.
- Avoid deprecation warnings when testing.