### PR TITLE
Fix error codes and support extended result codes

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -548,6 +548,22 @@ static VALUE set_busy_timeout(VALUE self, VALUE timeout)
   return self;
 }
 
+/* call-seq: db.extended_result_codes = true
+ *
+ * Enable extended result codes in SQLite.  These result codes allow for more
+ * detailed exception reporting, such a which type of constraint is violated.
+ */
+static VALUE set_extended_result_codes(VALUE self, VALUE enable)
+{
+  sqlite3RubyPtr ctx;
+  Data_Get_Struct(self, sqlite3Ruby, ctx);
+  REQUIRE_OPEN_DB(ctx);
+
+  CHECK(ctx->db, sqlite3_extended_result_codes(ctx->db, RTEST(enable) ? 1 : 0));
+
+  return self;
+}
+
 int rb_comparator_func(void * ctx, int a_len, const void * a, int b_len, const void * b)
 {
   VALUE comparator;
@@ -766,6 +782,7 @@ void init_sqlite3_database()
   rb_define_method(cSqlite3Database, "authorizer=", set_authorizer, 1);
   rb_define_method(cSqlite3Database, "busy_handler", busy_handler, -1);
   rb_define_method(cSqlite3Database, "busy_timeout=", set_busy_timeout, 1);
+  rb_define_method(cSqlite3Database, "extended_result_codes=", set_extended_result_codes, 1);
   rb_define_method(cSqlite3Database, "transaction_active?", transaction_active_p, 0);
   rb_define_private_method(cSqlite3Database, "db_filename", db_filename, 1);
 

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -90,5 +90,7 @@ void rb_sqlite3_raise(sqlite3 * db, int status)
       klass = rb_eRuntimeError;
   }
 
-  rb_raise(klass, "%s", sqlite3_errmsg(db));
+  klass = rb_exc_new2(klass, sqlite3_errmsg(db));
+  rb_iv_set(klass, "@code", INT2FIX(status));
+  rb_exc_raise(klass);
 }

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -4,7 +4,9 @@ void rb_sqlite3_raise(sqlite3 * db, int status)
 {
   VALUE klass = Qnil;
 
-  switch(status) {
+  /* Consider only lower 8 bits, to work correctly when
+     extended result codes are enabled. */
+  switch(status & 0xff) {
     case SQLITE_OK:
       return;
       break;

--- a/lib/sqlite3/errors.rb
+++ b/lib/sqlite3/errors.rb
@@ -2,17 +2,8 @@ require 'sqlite3/constants'
 
 module SQLite3
   class Exception < ::StandardError
-    @code = 0
-
-    # The numeric error code that this exception represents.
-    def self.code
-      @code
-    end
-
     # A convenience for accessing the error code for this exception.
-    def code
-      self.class.code
-    end
+    attr_reader :code
   end
 
   class SQLException < Exception; end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -53,6 +53,16 @@ module SQLite3
       assert_equal 1, e.code
     end
 
+    def test_extended_error_code
+      db.extended_result_codes = true
+      db.execute 'CREATE TABLE "employees" ("token" integer NOT NULL)'
+      begin
+        db.execute 'INSERT INTO employees (token) VALUES (NULL)'
+      rescue SQLite3::ConstraintException => e
+      end
+      assert_equal 1299, e.code
+    end
+
     def test_bignum
       num = 4907021672125087844
       db.execute 'CREATE TABLE "employees" ("token" integer(8), "name" varchar(20) NOT NULL)'

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -45,6 +45,14 @@ module SQLite3
       tf.unlink if tf
     end
 
+    def test_error_code
+      begin
+        db.execute 'SELECT'
+      rescue SQLite3::SQLException => e
+      end
+      assert_equal 1, e.code
+    end
+
     def test_bignum
       num = 4907021672125087844
       db.execute 'CREATE TABLE "employees" ("token" integer(8), "name" varchar(20) NOT NULL)'


### PR DESCRIPTION
Error code handling was previously completely broken, always returning nil. This fixes that and allows support for extended result codes, which provide more detail about what type of error has occurred (e.g. the specific type of constraint violated).