### PR TITLE
Add API for sending the "textrep" argument to sqlite3_create_function

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,9 @@
+=== 1.3.13
+
+* Enancements
+  * Support SQLite flags when defining functions
+  * Add definition for SQLITE_DETERMINISTIC flag
+
 === 1.3.12
 
 * Bugfixes:

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -303,12 +303,12 @@ int rb_proc_arity(VALUE self)
 }
 #endif
 
-/* call-seq: define_function(name) { |args,...| }
+/* call-seq: define_function_with_flags(name, flags) { |args,...| }
  *
- * Define a function named +name+ with +args+.  The arity of the block
+ * Define a function named +name+ with +args+ using TextRep bitflags +flags+.  The arity of the block
  * will be used as the arity for the function defined.
  */
-static VALUE define_function(VALUE self, VALUE name)
+static VALUE define_function_with_flags(VALUE self, VALUE name, VALUE flags)
 {
   sqlite3RubyPtr ctx;
   VALUE block;
@@ -323,7 +323,7 @@ static VALUE define_function(VALUE self, VALUE name)
     ctx->db,
     StringValuePtr(name),
     rb_proc_arity(block),
-    SQLITE_UTF8,
+    NUM2INT(flags),
     (void *)block,
     rb_sqlite3_func,
     NULL,
@@ -335,6 +335,16 @@ static VALUE define_function(VALUE self, VALUE name)
   rb_hash_aset(rb_iv_get(self, "@functions"), name, block);
 
   return self;
+}
+
+/* call-seq: define_function(name) { |args,...| }
+ *
+ * Define a function named +name+ with +args+.  The arity of the block
+ * will be used as the arity for the function defined.
+ */
+static VALUE define_function(VALUE self, VALUE name)
+{
+  return define_function_with_flags(self, name, SQLITE_UTF8)
 }
 
 static int sqlite3_obj_method_arity(VALUE obj, ID id)
@@ -773,6 +783,7 @@ void init_sqlite3_database()
   rb_define_method(cSqlite3Database, "trace", trace, -1);
   rb_define_method(cSqlite3Database, "last_insert_row_id", last_insert_row_id, 0);
   rb_define_method(cSqlite3Database, "define_function", define_function, 1);
+  rb_define_method(cSqlite3Database, "define_function_with_flags", define_function_with_flags, 2);
   rb_define_method(cSqlite3Database, "define_aggregator", define_aggregator, 2);
   rb_define_method(cSqlite3Database, "interrupt", interrupt, 0);
   rb_define_method(cSqlite3Database, "errmsg", errmsg, 0);

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -344,7 +344,7 @@ static VALUE define_function_with_flags(VALUE self, VALUE name, VALUE flags)
  */
 static VALUE define_function(VALUE self, VALUE name)
 {
-  return define_function_with_flags(self, name, SQLITE_UTF8)
+  return define_function_with_flags(self, name, SQLITE_UTF8);
 }
 
 static int sqlite3_obj_method_arity(VALUE obj, ID id)

--- a/lib/sqlite3/constants.rb
+++ b/lib/sqlite3/constants.rb
@@ -6,6 +6,7 @@ module SQLite3 ; module Constants
     UTF16BE = 3
     UTF16   = 4
     ANY     = 5
+    DETERMINISTIC = 0x800
   end
 
   module ColumnType

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -361,8 +361,8 @@ Support for this will be removed in version 2.0.0.
     #   end
     #
     #   puts db.get_first_value( "select maim(name) from table" )
-    def create_function name, arity, text_rep=Constants::TextRep::ANY, &block
-      define_function(name) do |*args|
+    def create_function name, arity, text_rep=Constants::TextRep::UTF8, &block
+      define_function_with_flags(name, text_rep) do |*args|
         fp = FunctionProxy.new
         block.call(fp, *args)
         fp.result

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -1,12 +1,12 @@
 module SQLite3
 
-  VERSION = '1.3.12'
+  VERSION = '1.3.13'
 
   module VersionProxy
 
     MAJOR = 1
     MINOR = 3
-    TINY  = 12
+    TINY  = 13
     BUILD = nil
 
     STRING = [ MAJOR, MINOR, TINY, BUILD ].compact.join( "." )


### PR DESCRIPTION
No breaking changes -- see commit msgs for details. The end game is to allow creating deterministic functions.