### PR TITLE
Add ruby24 to fat binaries and add mingw dependency tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,9 @@ source "https://rubygems.org/"
 
 
 gem "minitest", "~>5.9", :group => [:development, :test]
-gem "rake-compiler", "~>0.9.3", :group => [:development, :test]
-gem "rake-compiler-dock", "~>0.5.2", :group => [:development, :test]
+gem "rdoc", "~>4.0", :group => [:development, :test]
+gem "rake-compiler", "~>1.0", :group => [:development, :test]
+gem "rake-compiler-dock", "~>0.6.0", :group => [:development, :test]
 gem "mini_portile", "~>0.6.2", :group => [:development, :test]
 gem "hoe-bundler", "~>1.0", :group => [:development, :test]
 gem "hoe", "~>3.15", :group => [:development, :test]

--- a/rakelib/gem.rake
+++ b/rakelib/gem.rake
@@ -23,6 +23,7 @@ HOE = Hoe.spec 'sqlite3' do
   require_rubygems_version ">= 1.3.5"
 
   spec_extras[:extensions] = ["ext/sqlite3/extconf.rb"]
+  spec_extras[:metadata] = {'msys2_mingw_dependencies' => 'sqlite3'}
 
   extra_dev_deps << ['rake-compiler', "~> 1.0"]
   extra_dev_deps << ['rake-compiler-dock', "~> 0.6.0"]

--- a/rakelib/gem.rake
+++ b/rakelib/gem.rake
@@ -24,8 +24,8 @@ HOE = Hoe.spec 'sqlite3' do
 
   spec_extras[:extensions] = ["ext/sqlite3/extconf.rb"]
 
-  extra_dev_deps << ['rake-compiler', "~> 0.9.3"]
-  extra_dev_deps << ['rake-compiler-dock', "~> 0.5.2"]
+  extra_dev_deps << ['rake-compiler', "~> 1.0"]
+  extra_dev_deps << ['rake-compiler-dock', "~> 0.6.0"]
   extra_dev_deps << ["mini_portile", "~> 0.6.2"]
   extra_dev_deps << ["minitest", "~> 5.0"]
   extra_dev_deps << ["hoe-bundler", "~> 1.0"]

--- a/rakelib/native.rake
+++ b/rakelib/native.rake
@@ -40,6 +40,10 @@ RUBY_EXTENSION = Rake::ExtensionTask.new('sqlite3_native', HOE.spec) do |ext|
       Rake::ExtensionCompiler.mingw_host
       ext.cross_compile = true
       ext.cross_platform = ['i386-mswin32-60', 'i386-mingw32', 'x64-mingw32']
+      ext.cross_compiling do |spec|
+        # The fat binary gem doesn't depend on the sqlite3 package, since it bundles the library.
+        spec.metadata.delete('msys2_mingw_dependencies')
+      end
     rescue RuntimeError
       # noop
     end


### PR DESCRIPTION
Update rake-compiler and rake-compiler-dock to support ruby-2.4 fat binary gems. This drops support for ruby-1.9.3 binary gems.

In the second commit this adds msys2 library dependency tag in gem metadata.
    
RubyInstaller2 supports metadata tags for installation of dependent MSYS2/MINGW libraries. The sqlite3 source gem requires the sqlite3 library to be installed on the system, which the gem installer takes
care about, when this tag is set.
    
The feature is documented here: https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency
