### PR TITLE
Fix typo in ext/database.c

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -406,7 +406,7 @@ static VALUE define_aggregator(VALUE self, VALUE name, VALUE aggregator)
     rb_sqlite3_final
   );
 
-  rb_iv_set(self, "@agregator", aggregator);
+  rb_iv_set(self, "@aggregator", aggregator);
 
   CHECK(ctx->db, status);
 


### PR DESCRIPTION
Super minor, and I know there's a pull request open for aggregator functions, but I thought I'd fix this typo in the meantime.