### PR TITLE
Add gem build to Appveyor - update to 3.24.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ ports
 InstalledFiles
 Makefile
 Gemfile.lock
+
+# windows folders & files
+*.gem
+./Rakefile_wintest
+lib/fastfilereaderext.rb
+lib/rubyeventmachine.rb
+win_gem_test/shared/local_paths.ps1
+win_gem_test/shared/local_paths.ps1.sample
+win_gem_test/packages/
+win_gem_test/test_logs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,14 @@
 ---
-version: "{build}"
-branches:
-  only:
-    - master
-    - 1-3-stable
-clone_depth: 10
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - ruby --version
-  - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
-  - bundler --version
-  - bundle install
+  - set BRANCH=master
+
+  # Default path uses Ruby 1.9.3 ??
+  - set PATH=C:\Ruby25-x64\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
+
 build_script:
-  - rake native gem
-test_script:
-  - rake test
-artifacts:
-  - path: pkg\*.gem
+  - ps: .\win_gem_test\sqlite3-ruby.ps1 $env:gem_bits
 
 environment:
   matrix:
-    - ruby_version: "193"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
-    - ruby_version: "23"
-    - ruby_version: "23-x64"
-    - ruby_version: "24"
-    - ruby_version: "24-x64"
-    - ruby_version: "25"
-    - ruby_version: "25-x64"
+    - gem_bits: 64
+    - gem_bits: 32

--- a/win_gem_test/Rakefile_wintest
+++ b/win_gem_test/Rakefile_wintest
@@ -1,0 +1,11 @@
+# rake -f Rakefile_wintest -N -R norakelib
+
+require "rake/testtask"
+
+Rake::TestTask.new(:win_test) do |t|
+  t.libs << "test"
+  t.warning = nil
+  t.options = '--verbose'
+end
+
+task :default => [:win_test]

--- a/win_gem_test/package_gem.rb
+++ b/win_gem_test/package_gem.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/package'
+
+s = Gem::Specification::load("./sqlite3.gemspec")
+s.extensions = []
+
+s.files.concat ['Rakefile_wintest']
+s.files.concat Dir['lib/**/*.so']
+s.test_files = Dir['test/**/*.*']
+
+# below lines are required and not gem specific
+s.platform = ARGV[0]
+s.required_ruby_version = [">= #{ARGV[1]}", "< #{ARGV[2]}"]
+s.extensions = []
+if s.respond_to?(:metadata=)
+  s.metadata.delete("msys2_mingw_dependencies")
+  s.metadata['commit'] = ENV['commit_info']
+end
+
+Gem::Package.build(s)

--- a/win_gem_test/shared/appveyor_setup.ps1
+++ b/win_gem_test/shared/appveyor_setup.ps1
@@ -1,0 +1,325 @@
+# PowerShell script for updating MSYS2 / MinGW, installing OpenSSL and other packages
+# Code by MSP-Greg, see https://github.com/MSP-Greg/appveyor-utilities
+
+#————————————————————————————————————————————————————————————————————————————————— Make-Const
+# readonly, available in all session scripts
+function Make-Const($N, $V) {
+  New-Variable -Name $N -Value $V  -Scope Script -Option AllScope, Constant
+}
+
+#————————————————————————————————————————————————————————————————————————————————— Make-Vari
+# available in all session scripts
+function Make-Vari($N, $V) {
+  New-Variable -Name $N -Value $V  -Scope Script -Option AllScope
+}
+
+#————————————————————————————————————————————————————————————————————————————————— Constants
+if ($env:APPVEYOR) {
+  Make-Const dflt_ruby 'C:\ruby25-x64'
+  Make-Const in_av     $true
+  
+  # MinGW & Base Ruby
+  Make-Const msys2     'C:\msys64'
+  Make-Const dir_ruby  'C:\Ruby'
+  Make-const trunk     '26'
+
+  # DevKit paths
+  Make-Const DK32w     'C:\Ruby23\DevKit'
+  Make-Const DK64w     'C:\Ruby23-x64\DevKit'
+  
+  # Folder for storing downloaded packages
+  Make-Const pkgs      "$PSScriptRoot/../packages"
+
+  # Use simple base path without all Appveyor additions
+  Make-Const base_path 'C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\Git\cmd;'
+  
+  Make-Const 7z        "$env:ProgramFiles\7-Zip\7z.exe"
+  Make-Const fc        'Yellow'
+} else {
+  . $PSScriptRoot\local_paths.ps1
+}
+
+if( !(Test-Path -Path $pkgs -PathType Container) ) {
+  New-Item -Path $pkgs -ItemType Directory 1> $null
+}
+
+Make-Const dir_user  "$env:USERPROFILE\.gem\ruby\"
+Make-Const current_ruby_release 25
+# Download locations
+Make-Const ri1_pkgs  'https://dl.bintray.com/oneclick/OpenKnapsack'
+Make-Const ri2_pkgs  'https://dl.bintray.com/larskanis/rubyinstaller2-packages'
+Make-Const rubyloco  'https://dl.bintray.com/msp-greg/ruby_trunk'
+
+# Misc
+Make-Const SSL_CERT_FILE "$dflt_ruby\ssl\cert.pem"
+Make-Const ks1           'hkp://na.pool.sks-keyservers.net'
+Make-Const ks2           'hkp://pgp.mit.edu/'
+Make-Const dash          "$([char]0x2015)"
+Make-Const wc            $(New-Object System.Net.WebClient)
+
+Make-Vari  isRI2         # true for Ruby >= 2.4 (RubyInstaller2)
+Make-Vari  is64          # true for 64 bit
+Make-Vari  m             # MSYS2 package prefix
+Make-Vari  mingw         # mingw32 or mingw64
+Make-Vari  abi_vers      # ruby ABI vers, like '2.3.0'
+Make-Vari  gem_dflt      # Gem.default_dir
+Make-Vari  gem_user      # Gem.user_dir
+Make-Vari  gem_file_name # file name of gem
+Make-Vari  gem_full_name # full name of gem
+Make-Vari  commit_info   # full name of gem
+Make-Vari  dk_b          # DevKit folder
+Make-Vari  rv_min        # Gem min ruby version
+Make-Vari  rv_max        # Gem max ruby version
+Make-Vari  rubies
+
+Make-Vari  exit_code        0   # ExitCode from last exe
+Make-Vari  ttl_errors_fails 0   # Total of tests across all versions
+
+Make-Vari  need_refresh     $true
+Make-Vari  ssl_vhash        @{}   # hash of ssl version,
+
+#—————————————————————————————————————————————————————————————————————————————— Check-SetVars
+# assumes path is already set
+function Check-SetVars {
+  $isRI2 = $env:ruby_version -ge '24'         -Or  $env:ruby_version -eq '_trunk'
+  $is64  = $env:ruby_version.EndsWith('-x64') -Or  $env:ruby_version -eq '_trunk'
+
+  if ($is64) { $m = 'mingw-w64-x86_64-' ; $mingw = 'mingw64' }
+    else     { $m = 'mingw-w64-i686-'   ; $mingw = 'mingw32' }
+
+  if ( !($isRI2) ) { $env:SSL_CERT_FILE = $SSL_CERT_FILE }
+
+  $t = &ruby.exe -e "STDOUT.write Gem.default_dir + '|' + Gem.user_dir"
+  $gem_dflt, $gem_user = $t.Split('|')
+  $env:path += $gem_user.Replace('/', '\') + "\bin"
+  $abi_vers = &ruby.exe -e "STDOUT.write RUBY_VERSION[/\A\d+\.\d+/]"
+}
+
+#—————————————————————————————————————————————————————————————————————————————— Check-OpenSSL
+function Check-OpenSSL {
+  Check-SetVars
+
+  # Set OpenSSL versions - 2.4 uses standard MinGW 1.0.2 package
+  $openssl = if ($env:ruby_version -eq '_trunk') { 'openssl-1.1.0.h' } # trunk
+         elseif ($env:ruby_version -lt '20')     { 'openssl-1.0.0o'  } # 1.9.3
+         elseif ($env:ruby_version -lt '22')     { 'openssl-1.0.1l'  } # 2.0, 2.1, 2.2
+         elseif ($env:ruby_version -lt '24')     { 'openssl-1.0.2j'  } # 2.3
+         elseif ($env:ruby_version -lt '25')     { 'openssl-1.0.2o'  } # 2.4
+         else                                    { 'openssl-1.1.0.h' } # 2.5
+         
+  $bit = if ($is64) { '64 bit' } else { '32 bit'}
+         
+  if (!$isRI2) {
+    #————————————————————————————————————————————————————————————————————————— RubyInstaller
+    if ($is64) { $DKw = $DK64w ; $86_64 = 'x64' ; $dk_b = 'x86_64-w64-mingw32' }
+    else       { $DKw = $DK32w ; $86_64 = 'x86' ; $dk_b = 'i686-w64-mingw32'   }
+
+    $DKu = $DKw.Replace('\', '/')
+    if ($ssl_vhash[$86_64] -ne $openssl) {
+      # Install it
+      if ($is64) { DevKit-Package $openssl 64
+          } else { DevKit-Package $openssl 32 }
+      # Set hash to indicate it's loaded
+      $ssl_vhash[$86_64] = $openssl
+    } else {
+      Write-Host DevKit - $openssl $bit - Already installed -ForegroundColor $fc
+    }
+
+    $env:SSL_CERT_FILE = $SSL_CERT_FILE
+    $env:OPENSSL_CONF  = "$DKu/mingw/ssl/openssl.cnf"
+    $env:SSL_VERS = (&"$DKu/mingw/$dk_b/bin/openssl.exe" version | Out-String).Trim()
+  } else {
+    #————————————————————————————————————————————————————————————————————————— RubyInstaller2
+    if ($is64) { $key = '77D8FA18' ; $uri = $rubyloco ; $mingw = 'mingw64' }
+      else     { $key = 'BE8BF1C5' ; $uri = $ri2_pkgs ; $mingw = 'mingw32' }
+
+    if ($ssl_vhash[$mingw] -ne $openssl) {
+      Write-Host MSYS2/MinGW - $openssl $bit - Retrieving and installing -ForegroundColor $fc
+      $t = $openssl
+      if ($env:ruby_version.StartsWith('24')) {
+        &"$msys2\usr\bin\pacman.exe" -S --noconfirm --noprogressbar $($m + 'openssl')
+      } else {
+        $openssl = "$m$openssl-1-any.pkg.tar.xz"
+        if( !(Test-Path -Path $pkgs/$openssl -PathType Leaf) ) {
+          $wc.DownloadFile("$uri/$openssl"    , "$pkgs/$openssl")
+        }
+        if( !(Test-Path -Path $pkgs/$openssl.sig -PathType Leaf) ) {
+          $wc.DownloadFile("$uri/$openssl.sig", "$pkgs/$openssl.sig")
+        }
+        Push-Location -Path $msys2\usr\bin
+        $t1 = "pacman-key -r $key --keyserver $ks1 && pacman-key -f $key && pacman-key --lsign-key $key"
+        &"$msys2\usr\bin\bash.exe" -lc $t1 2> $null
+        $exit_code = $LastExitCode
+        Pop-Location
+        if ($exit_code -ne 0) {
+          # try another keyserver
+          $t1 = "pacman-key -r $key --keyserver $ks2 && pacman-key -f $key && pacman-key --lsign-key $key"
+          &"$msys2\usr\bin\bash.exe" -lc $t1 2> $null
+          $exit_code = $LastExitCode
+
+          if ($exit_code -ne 0) {
+            Write-Host GPG Key Lookup Failed! -ForegroundColor $fc
+            exit $exit_code
+          }
+        }
+
+        &"$msys2\usr\bin\pacman.exe" -Rdd --noconfirm --noprogressbar $($m + 'openssl')
+        &"$msys2\usr\bin\pacman.exe" -Udd --noconfirm --noprogressbar --force $pkgs/$openssl
+      }
+      $ssl_vhash[$mingw] = $t
+    } else {
+      Write-Host MSYS2/MinGW - $openssl $bit - Already installed -ForegroundColor $fc
+    }
+    $env:SSL_VERS = (&"$msys2\$mingw\bin\openssl.exe" version | Out-String).Trim()
+  }
+}
+
+#—————————————————————————————————————————————————————————————————————————————— Check-Update
+function Check-Update {
+  Check-SetVars
+  if ($isRI2) {
+    Write-Host "$($dash * 65) Updating MSYS2 / MinGW base-devel" -ForegroundColor $fc
+    $s = if ($need_refresh) { '-Sy' } else { '-S' }
+    try   { &"$msys2\usr\bin\pacman.exe" $s --noconfirm --needed --noprogressbar base-devel 2> $null }
+    catch { Write-Host 'Cannot update base-devel' }
+    Write-Host "$($dash * 65) Updating MSYS2 / MinGW toolchain" -ForegroundColor $fc
+    try   { &"$msys2\usr\bin\pacman.exe" -S --noconfirm --needed --noprogressbar $($m + 'toolchain') 2> $null }
+    catch { Write-Host 'Cannot update toolchain' }
+    $need_refresh = $false
+  }
+}
+
+#—————————————————————————————————————————————————————————————————————————————— DevKit-Package
+# $pkg parameter is <name-version>
+# $b parameter should be 32, 64, or null for both
+function DevKit-Package($pkg, $b) {
+  $bits = if ($b -eq 32 -Or $b -eq 64) { @($b) } else { @(32,64) }
+  foreach ($bit in $bits) {
+    if ($bit -eq 32) { 
+             $DKw = $DK32w ; $86_64 = 'x86' ; $dk_b = 'i686-w64-mingw32'   }
+      else { $DKw = $DK64w ; $86_64 = 'x64' ; $dk_b = 'x86_64-w64-mingw32' }
+
+    Write-Host DevKit - $pkg $bit bit - Retrieving and Installing... -ForegroundColor $fc
+    # Download & upzip into DK folder
+    $pkg_i = $pkg + '-' + $86_64 + '-windows.tar.lzma'
+    if( !(Test-Path -Path $pkgs/$pkg_i -PathType Leaf) ) {
+      $wc.DownloadFile("$ri1_pkgs/$86_64/$pkg_i", "$pkgs/$pkg_i")
+    }
+    $t = '-o' + $pkgs
+    &$7z e -y $pkgs\$pkg_i $t 1> $null
+    $pkg_i = $pkg_i -replace "\.lzma\z", ""
+    $p = "-o$DKw\mingw\$dk_b"
+    &$7z x -y $pkgs\$pkg_i $p 1> $null
+  }
+}
+
+function Load-Rubies {
+  # Make an array, like a range
+  $vers = $current_ruby_release..$ruby_vers_low
+  # add current trunk
+  if ($r_arch -eq 'x64-mingw32') { $vers = ,26 + $vers }
+  $rubies = @()
+  foreach ($v in $vers) {
+    if ( $v -eq 19 -and $r_arch -eq 'x64-mingw32' ) { continue }
+    
+    $rubies += switch ($v) {
+      19 { '193' }
+      20 { '200' }
+      default { [string]$v }
+    }
+  }
+  $max_minor = [int]($rubies[0].Substring(1,1)) + 1
+  $rv_min = $rubies[-1].Substring(0,1) + '.' + $rubies[-1].Substring(1,1)
+  $rv_max = $rubies[0].Substring(0,1)  + '.' + $max_minor
+}
+
+#—————————————————————————————————————————————————————————————————————————————— Install-Trunk
+function Install-Trunk {
+  $trunk_uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z'
+  $wc.DownloadFile($trunk_uri, 'C:\ruby_trunk.7z')
+  $trunk_param = "-o$dir_ruby$trunk" + "-x64"
+  &$7z x C:\ruby_trunk.7z $trunk_param
+}
+
+#—————————————————————————————————————————————————————————————————————————————— MSYS2-Package
+function MSYS2-Package($pkg) {
+  Check-SetVars
+  $s = if ($need_refresh) { '-Sy' } else { '-S' }
+  try   { &"$msys2\usr\bin\pacman.exe" $s --noconfirm --needed --noprogressbar $m$pkg }
+  catch { Write-Host "Cannot install/update $pkg package" }
+  if (!$ri2 -And $pkg -eq 'ragel') { $env:path += ";$msys2\$mingw\bin" }
+  $need_refresh = $false
+}
+
+#—————————————————————————————————————————————————————————————————————————————— Update-Gems
+# Call with a comma separated list of gems to update / install
+function Update-Gems($str_gems) {
+  $install = ''
+  $update  = ''
+  foreach ($gem in $str_gems) {
+    if ((iex "gem query -i $gem") -eq $False) { $install += " $gem" }
+                                         else { $update  += " $gem" }
+  }
+  $install = $install.trim(' ')
+  $update  = $update.trim(' ')
+
+  if ($update)  {
+    Write-Host "gem update $update -N -q -f" -ForegroundColor $fc
+    iex "gem update $update  -N -q -f"
+  }
+  if ($install) {
+    Write-Host "gem install $install -N -q -f" -ForegroundColor $fc
+    iex "gem install $install -N -q -f"
+  }
+  gem cleanup
+}
+
+# load r_archs
+[int]$temp = $args[0]
+if ($temp -eq 32) {
+  [string[]]$r_archs = 'i386-mingw32'
+  $args = @()
+} elseif ($temp -eq 64) {
+  [string[]]$r_archs = 'x64-mingw32'
+  $args = @()
+} else {
+  Write-Host "Must specify an platform (32 or 64)!" -ForegroundColor -fc
+  exit 1
+}
+
+#——————————————————————————————————————————————————————————————————————————————————————— Main
+# Update MSYS2 / MinGW or install MinGW packages passed as parameters
+# Pass --update to update MSYS2 / MinGW
+# Pass --strip with 2nd argument of array, strips all so files, can't be used with
+#  other args        
+# Pass openssl updates to correct version
+# Pass <package> package
+
+$need_refresh = $true                    # used to run pacman y option only once
+
+if ($args[0]) {
+  switch ( $args[0] ) {
+    '--strip' {
+      foreach ($arg in $args[1]) {
+        &"$msys2\$mingw\bin\strip.exe" --strip-unneeded -p $arg
+      }
+    }
+    default {
+      foreach ($arg in $args) {
+        switch ( $arg ) {
+          '--update' {
+            Check-Update
+          }
+          'openssl' {
+            Write-Host "$($dash * 65) Checking OpenSSL"
+            Check-OpenSSL
+          }
+          default {
+            Write-Host "$($dash * 65) Checking Package: $arg"
+            MSYS2-Package $arg
+          }
+        }
+      }
+    }
+  }
+}

--- a/win_gem_test/shared/make.ps1
+++ b/win_gem_test/shared/make.ps1
@@ -1,0 +1,149 @@
+<#
+PowerShell script for compiling all so files needed for fat binary gems
+
+This script is utility script, and should not require changes for any gems
+
+Code by MSP-Greg, see https://github.com/MSP-Greg/appveyor-utilities
+#>
+
+#———————————————————————————————————————————————————————— Process Repo
+Push-Location $dir_gem
+$commit_info = $(git.exe log -1 --pretty=format:'%ci   %h   %s')
+Write-Host "Commit Info: $commit_info`n" -ForegroundColor $fc
+
+# Remove tmp folder
+if ( Test-Path -Path $dir_gem\tmp -PathType Container ) {
+  Remove-Item  -Path $dir_gem\tmp -Recurse -Force
+}
+
+# Typically for patches, etc
+if (Get-Command Repo-Changes -errorAction SilentlyContinue) {
+  Repo-Changes
+}
+Pop-Location
+
+# Write fat binary rb files if used
+if ($write_so_require) {
+  foreach ($ext in $exts) {
+    $file_text = "require_relative `"#{RUBY_VERSION[/\A\d+\.\d+/]}/" + $ext.so + "`""
+    $fn = $ext.so + '.rb'
+    Out-File -FilePath $dir_gem\$dest_so\$fn -InputObject $file_text -Encoding UTF8
+  }
+}
+
+# Copy Rakefile_wintest if it exists
+if ( Test-Path -Path $dir_ps\Rakefile_wintest -PathType Leaf) {
+  Copy-Item -Path $dir_ps\Rakefile_wintest -Destination $dir_gem -Force
+}
+
+foreach ($r_arch in $r_archs) {
+
+  [string[]]$so_dests = @()
+
+  if ($r_arch -eq 'x64-mingw32')
+        { $suf = '-x64' ; $dk = $DK64w ; $plat = 'x64-mingw32' }
+   else { $suf = ''     ; $dk = $DK32w ; $plat = 'x86-mingw32' }
+
+  # Update MSYS2 base files (toolchain & base-devel)
+  $env:ruby_version = "24$suf"
+  Check-SetVars
+  Check-Update
+  Load-Rubies
+
+  foreach ($ruby in $rubies) {
+    if ( $in_av -and $ruby -eq $trunk ) { Install-Trunk }
+
+    # Loop if ruby version does not exist
+    if ( !( Test-Path -Path $dir_ruby$ruby$suf  -PathType Container) ) {
+      $foreach.MoveNext | Out-Null }
+   
+    # Set up path with Ruby bin
+    $env:path = "$dir_ruby$ruby$suf\bin;"
+
+    # Add build system bin folders
+    $env:path += if ($ruby -ge '24') { "$msys2\$mingw\bin;$msys2\usr\bin;" }
+                                else { "$dk\mingw\bin;$dk\bin;"            }
+
+    # Add base items
+    $env:path += $base_path
+    
+    # match Appveyor variable for use in appveyor_setup.ps1
+    $env:ruby_version = "$ruby$suf"
+
+    # Out info to console
+    Write-Host "`n$($dash * 75) ruby$ruby$suf" -ForegroundColor $fc
+    Check-SetVars
+    ruby.exe -v
+    Write-Host RubyGems (gem --version)
+
+    if (Get-Command Pre-Compile -errorAction SilentlyContinue) {
+      Pre-Compile
+    }
+
+    $dest = "$dir_gem\$dest_so\$abi_vers"
+    if ( !( Test-Path -Path $dest  -PathType Container) ) {
+      New-Item -Path $dest -ItemType Directory 1> $null
+    }
+    $so_dests += $dest
+    foreach ($ext in $exts) {
+      $so = $ext.so
+      $src_dir = "$dir_gem\tmp\$r_arch\$so\$abi_vers"
+      New-Item -Path $src_dir -ItemType Directory 1> $null
+      Push-Location -Path $src_dir
+      Write-Host "`n$($dash * 50)" Compiling ruby$ruby$suf $ext.so -ForegroundColor $fc
+      if ($env:b_config) {
+        Write-Host "options:$($env:b_config.replace("--", "`n   --"))" -ForegroundColor $fc
+      }
+      # Invoke-Expression needed due to spaces in $env:b_config
+      iex "ruby.exe -I. $dir_gem\$($ext.conf) $env:b_config"
+      if ($isRI2) { make -j2 } else { make }
+      $exit_code = $LastExitCode
+      if ($exit_code -ne 0) {
+        Pop-Location
+        Write-Host Make Failed! -ForegroundColor $fc
+        exit $exit_code
+      }
+      $fn = $so + '.so'
+      Write-Host Creating $dest_so\$abi_vers\$fn
+      Copy-Item -Path $fn -Destination $dest\$fn -Force
+      Pop-Location
+    }
+  }
+  # Strip all *.so files
+  [string[]]$sos = Get-ChildItem -Include *.so -Path $dir_gem\$dest_so -Recurse | select -expand fullname
+  foreach ($so in $sos) {
+    &"$msys2\$mingw\bin\strip.exe" --strip-unneeded -p $so
+  }
+
+  # package gem
+  Write-Host "`n$($dash * 60)" Packaging Gem $plat -ForegroundColor $fc
+  $env:path = $dir_ruby + "25-x64\bin;$base_path"
+
+  Push-Location $dir_gem
+  $env:commit_info = $commit_info
+  ruby.exe $dir_ps\package_gem.rb $plat $rv_min $rv_max | Tee-Object -Variable bytes
+  Remove-Item Env:commit_info
+  Pop-Location
+  $bytes = [System.Text.Encoding]::Unicode.GetBytes($bytes)
+  $t = @()
+  foreach ($b in $bytes) {
+    if ($b -ne 0) { $t += $b }
+  }
+  
+  $gem_out = [System.Text.Encoding]::UTF8.GetString($t)
+
+  $gem_file_name = if ($gem_out -imatch "\s+File:\s+(\S+)") { $matches[1]
+  } else { exit 1 }
+  
+  $gem_full_name = $gem_file_name -replace '\.gem$', ''
+
+  # remove so folders
+  foreach ($so_dest in $so_dests) { Remove-Item  -Path $so_dest -Recurse -Force }
+
+  #————————————————————————————————————————————————————————— save gems if appveyor
+  if ($in_av) {
+    Write-Host "`nSaving $gem_file_name as artifact" -ForegroundColor $fc
+    $fn = $dir_gem + '/' + $gem_file_name
+    Push-AppveyorArtifact $fn
+  }
+}

--- a/win_gem_test/shared/test.ps1
+++ b/win_gem_test/shared/test.ps1
@@ -1,0 +1,160 @@
+<#
+PowerShell script for testing of fat binary gems
+
+This script is utility script, and should not require changes for any gems
+
+Code by MSP-Greg, see https://github.com/MSP-Greg/appveyor-utilities
+#>
+
+if ($exit_code -ne 0) { exit $exit_code }
+
+New-Variable -Name log_name     -Value '' -Option AllScope -Scope Script
+New-Variable -Name r_arch       -Value '' -Option AllScope -Scope Script
+
+New-Variable -Name test_results -Value '' -Option AllScope -Scope Script
+New-Variable -Name test_summary -Value '' -Option AllScope -Scope Script
+New-Variable -Name gem_full     -Value '' -Option AllScope -Scope Script
+
+$dt = Get-Date -UFormat "%Y-%m-%d_%H-%M"
+
+function Get-MS {
+  if ($test_results -match "(?ms)^Finished in (\d+\.\d{3})" ) {
+    return [int]([math]::Round([float]$matches[1]) * 1000)
+  } else { return $null}
+}
+
+function Get-Std-Out {
+  $stdout = if ($test_results.length -le 4000) {
+    $test_results
+  } elseif ($test_results -match "(?ms)^Finished in \d+\.\d{3}.+" ) {
+    $matches[0]
+  } else {
+    $test_results.Substring($test_results.length - 4000)
+  }
+  return $stdout
+}
+
+function Process-Log {
+  ruby -v      | Add-Content -Path $log_name -PassThru -Encoding UTF8
+  $commit_info | Add-Content -Path $log_name -PassThru -Encoding UTF8
+  (Get-Content $log_name).replace("$gem_dflt/gems/", "") | Set-Content $log_name -Encoding UTF8
+  $test_results = [System.Io.File]::ReadAllText($log_name)
+}
+
+function AV-Test($outcome) {
+  $std_out = Get-Std-Out
+  if ($outcome -eq 'Failed') {
+    Add-AppveyorTest -Name "Ruby$ruby$suf" -Outcome 'Failed' `
+      -StdOut $std_out -Framework "ruby" -FileName $gem_full
+  } else {
+    $oc = if ($outcome -eq 0) {'Passed'} else {'Failed'}
+    $ms = Get-MS
+    Add-AppveyorTest -Name "Ruby$ruby$suf" -Outcome $oc -Duration $ms `
+      -StdOut $std_out -Framework "ruby" -FileName $gem_full
+  }
+}
+
+# minitest result parser
+function minitest {
+  Process-Log
+  if ($test_summary -eq '') {
+    $test_summary   = " Runs  Asserts  Fails  Errors  Skips  Ruby"
+  }
+
+  if ($test_results -match "(?m)^\d+ runs.+ skips") {
+    $ary = ($matches[0] -replace "[^\d]+", ' ').Trim().Split(' ')
+    $errors_fails = [int]$ary[2] + [int]$ary[3]
+    if ($in_av) { AV-Test $errors_fails }
+    $ttl_errors_fails += $errors_fails
+    $ary += @("Ruby$ruby$suf") + $ruby_v
+    $test_summary += "`n{0,4:n}    {1,4:n}   {2,4:n}    {3,4:n}    {4,4:n}   {5,-11} {6,-15} ({7}" -f $ary
+  } else {
+    if ($in_av) { AV-Test 'Failed' }
+    $ttl_errors_fails += 1000
+    $ary = @("Ruby$ruby$suf") + $ruby_v
+    $test_summary += "`ntesting aborted?                      {0,-11} {1,-15} ({2}" -f $ary
+  }
+}
+
+# test-unit results parser
+function test_unit {
+  Process-Log
+
+  if ($test_summary -eq '') {
+    $test_summary    = "Tests  Asserts  Fails  Errors  Pend  Omitted  Notes  Ruby"
+  }
+
+  $results = 
+  if ($test_results -match "(?m)^\d+ tests.+ notifications") {
+    $ary = ($matches[0] -replace "[^\d]+", ' ').Trim().Split(' ')
+    $errors_fails = [int]$ary[2] + [int]$ary[3]
+    if ($in_av) { AV-Test $errors_fails }
+    $ttl_errors_fails += $errors_fails
+    $ary += @("Ruby$ruby$suf") + $ruby_v
+    $test_summary += "`n{0,4:n}    {1,4:n}   {2,4:n}    {3,4:n}   {4,4:n}    {5,4:n}   {6,4:n}    {7,-11} {8,-15} ({9}" -f $ary
+  } else {
+    if ($in_av) { AV-Test 'Failed' }
+    $ary = @("Ruby$ruby$suf") + $ruby_v
+    $ttl_errors_fails += 1000
+    $test_summary += "`ntesting aborted?                                     {0,-11} {1,-15} ({2}" -f $ary
+  }
+}
+
+#————————————————————————————————————————————————————————————————————————————————— Main
+
+# create test log folder
+if (Test-Path -Path $dir_ps\test_logs -PathType Container) {
+  Remove-Item $dir_ps\test_logs\*.txt
+} else {
+  New-Item -Path $dir_ps\test_logs -ItemType Directory 1> $null
+}
+
+# loop thru all versions
+foreach ($r_arch in $r_archs) {
+  if ($r_arch -eq 'x64-mingw32') { $suf = '-x64' ; $plat = 'x64-mingw32' }
+                            else { $suf = ''     ; $plat = 'x86-mingw32' }
+
+  $fn = $dir_gem + '/' + $gem_file_name
+  Load-Rubies
+
+  foreach ($ruby in $rubies) {
+    # Loop if ruby version does not exist
+    if( !(Test-Path -Path $dir_ruby$ruby$suf -PathType Container) ) { $foreach.MoveNext | Out-Null }
+
+    # Set up path with Ruby bin
+    $env:path =  "$dir_ruby$ruby$suf\bin;" + $base_path
+    $env:ruby_version = "$ruby$suf"
+    Check-SetVars
+
+    Write-Host "`n$($dash * 75) Testing Ruby$ruby$suf" -ForegroundColor $fc
+    if ( !($in_av) ) { gem uninstall $gem_name -x -a }
+    gem install $fn -Nl
+
+    # Find where gem was installed - default or user
+    $rake_dir = $gem_dflt + '/gems/' + $gem_full_name
+    if ( !(Test-Path -Path $rake_dir -PathType Container) ) {
+      $rake_dir = "$gem_user/gems/$gem_full_name"
+      if ( !(Test-Path -Path $rake_dir -PathType Container) ) { continue }
+    }
+    $ruby_v = [regex]::split( (ruby.exe -v | Out-String).Replace(" [$r_arch]", '').Trim(), ' \(')
+    $log_name = "$dir_ps\test_logs\Ruby$ruby$suf" + ".txt"
+    ruby.exe -v
+    Push-Location $rake_dir
+    Run-Tests
+    Pop-Location
+  }
+}
+# collect all log files
+#$dt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd_HH-mm")
+#$fn_log = "$dir_ps\test_logs\test_logs-$plat-$dt" + ".7z"
+$fn_log = "$dir_ps\test_logs\test_logs-$plat" + ".7z"
+&$7z a $fn_log $dir_ps\test_logs\*.txt 1> $null
+
+if ($in_av) { Push-AppveyorArtifact $fn_log }
+
+Write-Host "`n$($dash * 50) $gem_full_name Test Summary" -ForegroundColor $fc
+Write-Host $test_summary
+Write-Host ($dash * 88) -ForegroundColor $fc
+Write-Host "`nCommit Info: $commit_info`n" -ForegroundColor $fc
+
+

--- a/win_gem_test/sqlite3-ruby.ps1
+++ b/win_gem_test/sqlite3-ruby.ps1
@@ -1,0 +1,95 @@
+# PowerShell script setting base variables for EventMachine fat binary gem
+# Code by MSP-Greg, see https://github.com/MSP-Greg/appveyor-utilities
+
+# load utility functions, pass 64 or 32
+. $PSScriptRoot\shared\appveyor_setup.ps1 $args[0]
+
+# above is required code
+#———————————————————————————————————————————————————————————————— above for all repos
+
+Make-Const gem_name  'sqlite3'
+Make-Const repo_name 'sqlite3-ruby'
+Make-Const url_repo  'https://github.com/sparklemotion/sqlite3-ruby.git'
+
+#———————————————————————————————————————————————————————————————— lowest ruby version
+Make-Const ruby_vers_low 20
+
+#———————————————————————————————————————————————————————————————— make info
+$sql_vers = '3240000'
+$sql_year = '2018'
+
+$sql_url  = 'https://sqlite.org'
+$sql_pre  = 'sqlite-autoconf-'
+
+#———————————————————————————————————————————————————————————————— make info
+Make-Const dest_so  'lib\sqlite3'
+Make-Const exts     @( @{ 'conf' = 'ext/sqlite3/extconf.rb' ; 'so' = 'sqlite3_native' } )
+Make-Const write_so_require $false
+
+#———————————————————————————————————————————————————————————————— repo changes
+function Repo-Changes {
+  # zlib dll is bundled with RI builds, but files are not in DevKit
+  DevKit-Package 'zlib-1.2.8'
+}
+
+#———————————————————————————————————————————————————————————————— pre compile
+function Pre-Compile {
+
+  $new_path = "$dir_gem\tmp\$r_arch\ports"
+  
+  # only compile first RI2 if 64 bit
+  if ( (!$is64 -And $ruby -eq '23') -Or $ruby -eq $rubies[0] ){
+    Write-Host "Compiling SQLite..." -ForegroundColor $fc
+    $fn = "$sql_pre$sql_vers.tar.gz"
+    $fp = "$pkgs\$fn"
+    if( !(Test-Path -Path $fp -PathType Leaf) ) {
+      $wc.DownloadFile("$sql_url/$sql_year/$fn", $fp)
+    }
+    $t = "-o$pkgs"
+    &$7z e -y $fp $t 1> $null
+    $fp = $fp -replace "\.gz\z", ""
+    &$7z x -y $fp $t 1> $null
+
+    if (Test-Path -Path $new_path -PathType Container) {
+      Remove-Item -Path $new_path -Recurse -Force
+    }
+    New-Item -Path $new_path -ItemType Directory 1> $null
+    
+    # Move SQLite contents to $new_path
+    Get-ChildItem -Path "$pkgs\$sql_pre$sql_vers" -Recurse |
+      Move-Item  -force -destination $new_path
+
+    Push-Location $new_path
+    if ($is64) {
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA -fPIC" --disable-shared
+      make -j2
+    } else {
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA" --disable-shared
+      make
+    }
+    Pop-Location
+  }
+  $t = $new_path.replace('\', '/')
+  $env:b_config = " --with-sqlite3-dir=$t --with-opt-include=$t --with-sqlite3-lib=$t/.libs"
+}
+
+#———————————————————————————————————————————————————————————————— Run-Tests
+function Run-Tests {
+  Update-Gems minitest, rake
+  rake -f Rakefile_wintest -N -R norakelib | Set-Content -Path $log_name -PassThru -Encoding UTF8
+  $(ruby -rsqlite3 -e "STDOUT.write 'SQLite3::SQLITE_VERSION ' ; puts SQLite3::SQLITE_VERSION") |
+    Add-Content -Path $log_name -PassThru -Encoding UTF8
+  minitest
+}
+
+#———————————————————————————————————————————————————————————————— below for all repos
+# below is required code
+Make-Const dir_gem  $(Convert-Path $PSScriptRoot\..)
+Make-Const dir_ps   $PSScriptRoot
+
+Push-Location $PSScriptRoot
+.\shared\make.ps1
+.\shared\test.ps1
+Pop-Location
+
+exit $ttl_errors_fails + $exit_code


### PR DESCRIPTION
Testing on Appveyor does almost all the work required to build a fat-binary gem.  Adding six files, three specific to sqlite3-ruby, allows creating the fat-binary gem, and also uses it for testing.

64 bit gem is 2.0 <= ruby vers <= 2.6 (trunk).  32 bit gem is 2.0 <= ruby vers <= 2.5.

See results at my fork https://ci.appveyor.com/project/MSP-Greg/sqlite3-ruby/build/2