### PR TITLE
Build Windows fat-binary gems on Appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ ports
 InstalledFiles
 Makefile
 Gemfile.lock
+
+# windows local build artifacts
+win_gem_test/shared/
+win_gem_test/test_logs/
+/Rakefile_wintest
+*.gem

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,36 +1,20 @@
 ---
-version: "{build}"
-branches:
-  only:
-    - master
-    - 1-3-stable
-clone_depth: 10
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - ruby --version
-  - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
-  - bundler --version
-  - bundle install
+  - ps: >-
+      if ( !(Test-Path -Path ./shared -PathType Container) ) {
+        $uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/av-gem-build-test/artifacts/shared.7z'
+        $7z  = 'C:\Program Files\7-Zip\7z.exe'
+        $fn = "$env:TEMP\shared.7z"
+        (New-Object System.Net.WebClient).DownloadFile($uri, $fn)
+        &$7z x $fn -owin_gem_test 1> $null
+        Remove-Item  -LiteralPath $fn -Force
+        Write-Host "Downloaded shared files" -ForegroundColor Yellow 
+      }
+
 build_script:
-  - rake native gem
-test_script:
-  - rake test
-artifacts:
-  - path: pkg\*.gem
+  - ps: .\win_gem_test\sqlite3-ruby.ps1 $env:gem_bits
 
 environment:
   matrix:
-    - ruby_version: "193"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
-    - ruby_version: "23"
-    - ruby_version: "23-x64"
-    - ruby_version: "24"
-    - ruby_version: "24-x64"
-    - ruby_version: "25"
-    - ruby_version: "25-x64"
+    - gem_bits: 64
+    - gem_bits: 32

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -64,10 +64,12 @@ end
 asplode('sqlite3.h')  unless find_header  'sqlite3.h'
 find_library 'pthread', 'pthread_create' # 1.8 support. *shrug*
 
-have_library 'dl'
+unless RUBY_PLATFORM[/mingw|mswin/]
+  have_library 'dl'
 
-%w{ dlopen dlclose dlsym }.each do |func|
-  abort "missing function #{func}" unless have_func(func)
+  %w{ dlopen dlclose dlsym }.each do |func|
+    abort "missing function #{func}" unless have_func(func)
+  end
 end
 
 if with_config('sqlcipher')

--- a/win_gem_test/Rakefile_wintest
+++ b/win_gem_test/Rakefile_wintest
@@ -1,0 +1,11 @@
+# rake -f Rakefile_wintest -N -R norakelib
+
+require "rake/testtask"
+
+Rake::TestTask.new(:win_test) do |t|
+  t.libs << "test"
+  t.warning = nil
+  t.options = '--verbose'
+end
+
+task :default => [:win_test]

--- a/win_gem_test/package_gem.rb
+++ b/win_gem_test/package_gem.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/package'
+
+s = Gem::Specification::load("./sqlite3.gemspec")
+s.extensions = []
+
+s.files.concat ['Rakefile_wintest']
+s.files.concat Dir['lib/**/*.so']
+s.test_files = Dir['test/**/*.*']
+
+# below lines are required and not gem specific
+s.platform = ARGV[0]
+s.required_ruby_version = [">= #{ARGV[1]}", "< #{ARGV[2]}"]
+s.extensions = []
+if s.respond_to?(:metadata=)
+  s.metadata.delete("msys2_mingw_dependencies")
+  s.metadata['commit'] = ENV['commit_info']
+end
+
+Gem::Package.build(s)

--- a/win_gem_test/sqlite3-ruby.ps1
+++ b/win_gem_test/sqlite3-ruby.ps1
@@ -1,0 +1,104 @@
+# PowerShell script for building & testing SQLite3-Ruby fat binary gem
+# Code by MSP-Greg, see https://github.com/MSP-Greg/av-gem-build-test
+
+# load utility functions, pass 64 or 32
+. $PSScriptRoot\shared\appveyor_setup.ps1 $args[0]
+if ($LastExitCode) { exit }
+
+# above is required code
+#———————————————————————————————————————————————————————————————— above for all repos
+
+Make-Const gem_name  'sqlite3'
+Make-Const repo_name 'sqlite3-ruby'
+Make-Const url_repo  'https://github.com/sparklemotion/sqlite3-ruby.git'
+
+#———————————————————————————————————————————————————————————————— lowest ruby version
+Make-Const ruby_vers_low 20
+
+#———————————————————————————————————————————————————————————————— SQLite package info
+$sql_vers = '3240000'
+$sql_year = '2018'
+
+$sql_url  = 'https://sqlite.org'
+$sql_pre  = 'sqlite-autoconf-'
+
+#———————————————————————————————————————————————————————————————— make info
+Make-Const dest_so  'lib\sqlite3'
+Make-Const exts     @( @{ 'conf' = 'ext/sqlite3/extconf.rb' ; 'so' = 'sqlite3_native' } )
+Make-Const write_so_require $false
+
+#———————————————————————————————————————————————————————————————— repo changes
+function Repo-Changes {
+  # zlib build files are normally in MSYS2 installations,
+  # but they are not in DevKit
+  Package-DevKit 'zlib-1.2.8'
+}
+
+#———————————————————————————————————————————————————————————————— pre compile
+function Pre-Compile {
+  # This function is used to compile SQLite, as defined by variables above.
+  # We don't need to compile this for every Ruby version.
+  # For 64 bit, all versions (2.0 thru trunk) seemed to work with a MSYS2
+  # compiled version.
+  # For 32 bit, needed to separately compile for versions <= 2.3 (DevKit), and
+  # > 2.3 (RI2 / MSYS2).
+
+  $new_path = "$dir_gem\tmp\$r_arch\ports"
+  
+  # only compile first RI2 if 64 bit
+  if ( (!$is64 -And $ruby -eq '23') -Or $ruby -eq $rubies[0] ){
+    Write-Host "Compiling SQLite..." -ForegroundColor $fc
+    $fn = "$sql_pre$sql_vers.tar.gz"
+    $fp = "$pkgs\$fn"
+    if( !(Test-Path -Path $fp -PathType Leaf) ) {
+      $wc.DownloadFile("$sql_url/$sql_year/$fn", $fp)
+    }
+    $t = "-o$pkgs"
+    &$7z e -y $fp $t 1> $null
+    $fp = $fp -replace "\.gz\z", ""
+    &$7z x -y $fp $t 1> $null
+
+    if (Test-Path -Path $new_path -PathType Container) {
+      Remove-Item -Path $new_path -Recurse -Force
+    }
+    New-Item -Path $new_path -ItemType Directory 1> $null
+    
+    # Move SQLite contents to $new_path
+    Get-ChildItem -Path "$pkgs\$sql_pre$sql_vers" -Recurse |
+      Move-Item  -force -destination $new_path
+
+    Push-Location $new_path
+    if ($is64) {
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA -fPIC" --disable-shared
+      make -j2
+    } else {
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA" --disable-shared
+      make
+    }
+    Pop-Location
+  }
+  $t = $new_path.replace('\', '/')
+  $env:b_config = " --with-sqlite3-dir=$t --with-opt-include=$t --with-sqlite3-lib=$t/.libs"
+}
+
+#———————————————————————————————————————————————————————————————— Run-Tests
+function Run-Tests {
+  Update-Gems minitest, rake
+  rake -f Rakefile_wintest -N -R norakelib | Set-Content -Path $log_name -PassThru -Encoding UTF8
+  # add info after test results
+  $(ruby -rsqlite3 -e "STDOUT.write $/ + 'SQLite3::SQLITE_VERSION ' ; puts SQLite3::SQLITE_VERSION") |
+    Add-Content -Path $log_name -PassThru -Encoding UTF8
+  minitest
+}
+
+#———————————————————————————————————————————————————————————————— below for all repos
+# below is required code
+Make-Const dir_gem  $(Convert-Path $PSScriptRoot\..)
+Make-Const dir_ps   $PSScriptRoot
+
+Push-Location $PSScriptRoot
+.\shared\make.ps1
+.\shared\test.ps1
+Pop-Location
+
+exit $ttl_errors_fails + $exit_code

--- a/win_gem_test/sqlite3-ruby.ps1
+++ b/win_gem_test/sqlite3-ruby.ps1
@@ -43,7 +43,7 @@ function Pre-Compile {
   # For 32 bit, needed to separately compile for versions <= 2.3 (DevKit), and
   # > 2.3 (RI2 / MSYS2).
 
-  $new_path = "$dir_gem\tmp\$r_arch\ports"
+  $new_path = "$dir_gem\tmp\ports"
   
   # only compile first RI2 if 64 bit
   if ( (!$is64 -And $ruby -eq '23') -Or $ruby -eq $rubies[0] ){
@@ -69,10 +69,10 @@ function Pre-Compile {
 
     Push-Location $new_path
     if ($is64) {
-      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA -fPIC" --disable-shared
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA -fPIC" LDFLAGS="-static-libgcc" --disable-shared
       make -j2
     } else {
-      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA" --disable-shared
+      bash Configure CFLAGS="-O2 -DSQLITE_ENABLE_COLUMN_METADATA" LDFLAGS="-static-libgcc" --disable-shared
       make
     }
     Pop-Location

--- a/win_gem_test/sqlite3-ruby.ps1
+++ b/win_gem_test/sqlite3-ruby.ps1
@@ -16,8 +16,8 @@ Make-Const url_repo  'https://github.com/sparklemotion/sqlite3-ruby.git'
 Make-Const ruby_vers_low 20
 
 #———————————————————————————————————————————————————————————————— SQLite package info
-$sql_vers = '3240000'
-$sql_year = '2018'
+$sql_vers = '3270100'
+$sql_year = '2019'
 
 $sql_url  = 'https://sqlite.org'
 $sql_pre  = 'sqlite-autoconf-'

--- a/win_gem_test/sqlite3-ruby.ps1
+++ b/win_gem_test/sqlite3-ruby.ps1
@@ -16,7 +16,7 @@ Make-Const url_repo  'https://github.com/sparklemotion/sqlite3-ruby.git'
 Make-Const ruby_vers_low 20
 
 #———————————————————————————————————————————————————————————————— SQLite package info
-$sql_vers = '3270100'
+$sql_vers = '3280000'
 $sql_year = '2019'
 
 $sql_url  = 'https://sqlite.org'


### PR DESCRIPTION
Changes Appveyor CI to allow fat-binary gem construction along with testing.

Also patches extconf.rb since SQLite appears to account for dl functions when compiled under windows.