### PR TITLE
travis.yml - fix gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 sudo: false
 language: ruby
 cache: bundler
+
 before_install:
-  - gem update --system
-  - gem install bundler
+  # rubygems 2.7.8 and greater include bundler, also with Ruby 2.6
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
+    elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
+    fi
+  # - gem install bundler
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   # rubygems 2.7.8 and greater include bundler, also with Ruby 2.6
   - |
     rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
-    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.8 --no-document
+    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.9 --no-document
     elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
     fi
   # - gem install bundler


### PR DESCRIPTION
RubyGems is updated in travis.yml.

With the release of RubyGems 3.0, it's own ignorance of `required_ruby_version` causes it to not be able to update itself.  PR fixes that by adding conditional script code.

Since both RubyGems 2.7.8 & current versions include Bundler, commented out its update.