### PR TITLE
Fix required ruby version in gem

### DIFF
--- a/rakelib/gem.rake
+++ b/rakelib/gem.rake
@@ -19,7 +19,7 @@ HOE = Hoe.spec 'sqlite3' do
   self.history_file  = 'CHANGELOG.rdoc'
   self.extra_rdoc_files  = FileList['*.rdoc', 'ext/**/*.c']
 
-  require_ruby_version ">= 1.8.7"
+  require_ruby_version ">= 1.9.2"
   require_rubygems_version ">= 1.3.5"
 
   spec_extras[:extensions] = ["ext/sqlite3/extconf.rb"]


### PR DESCRIPTION
The gem no longer builds on 1.8.7 as it requires encoding supported added in ruby 1.9.