### PR TITLE
 Don't mandate dl functions for the extention build

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -64,11 +64,7 @@ end
 asplode('sqlite3.h')  unless find_header  'sqlite3.h'
 find_library 'pthread', 'pthread_create' # 1.8 support. *shrug*
 
-have_library 'dl'
-
-%w{ dlopen dlclose dlsym }.each do |func|
-  abort "missing function #{func}" unless have_func(func)
-end
+have_library 'dl' # for static builds
 
 if with_config('sqlcipher')
   asplode('sqlcipher') unless find_library 'sqlcipher', 'sqlite3_libversion_number'


### PR DESCRIPTION
Sqlite3-ruby doesn't use dl functions, nor does extconf compile sqlite3 sources, which possibly makes use of them. So mandating dl functions in extconf is wrong and breaks the build on Windows.

Fixes #250 .

This reverts commit f4ffec281a2888c1e536662ac1ea740fd3f5433c.