### PR TITLE
Add dlfcn as dependency for MSYS2

### DIFF
--- a/rakelib/gem.rake
+++ b/rakelib/gem.rake
@@ -23,7 +23,7 @@ HOE = Hoe.spec 'sqlite3' do
   require_rubygems_version ">= 1.3.5"
 
   spec_extras[:extensions] = ["ext/sqlite3/extconf.rb"]
-  spec_extras[:metadata] = {'msys2_mingw_dependencies' => 'sqlite3'}
+  spec_extras[:metadata] = {'msys2_mingw_dependencies' => 'sqlite3 dlfcn'}
 
   extra_dev_deps << ['rake-compiler', "~> 1.0"]
   extra_dev_deps << ['rake-compiler-dock', "~> 0.6.0"]

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = "1.3.13.20180326210955"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.5".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "msys2_mingw_dependencies" => "sqlite3" } if s.respond_to? :metadata=
+  s.metadata = { "msys2_mingw_dependencies" => "sqlite3 dlfcn" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Jamis Buck".freeze, "Luis Lavena".freeze, "Aaron Patterson".freeze]
   s.date = "2018-03-26"


### PR DESCRIPTION
Add the "dlfcn" library as MSYS2 dependency for RubyInstaller2.
This fixes the "missing function dlopen" error during installation.
(Introduced with f4ffec281a2888c1e536662ac1ea740fd3f5433c, cc @tenderlove.)

This fixes #259 and is an alternative solution to #254, assuming that dlfcn _is_ necessary for sqlite3.

This essentially has been suggested by @MSP-Greg in #250.

I need to say that I have no idea whether adding this dependency might have some undesired side effects.

_Also note that the gemspec is outdated (wrong version, dates, ...). I regenerated with `rake gem:spec`, but only committed the relevant line._