### PR TITLE
Add dlfcn to msys2_mingw_dependencies

### DIFF
--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = "1.3.13.20180326210955"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.5".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "msys2_mingw_dependencies" => "sqlite3" } if s.respond_to? :metadata=
+  s.metadata = { "msys2_mingw_dependencies" => "sqlite3 dlfcn" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Jamis Buck".freeze, "Luis Lavena".freeze, "Aaron Patterson".freeze]
   s.date = "2018-03-26"


### PR DESCRIPTION
Added dlfcn to msys2_mingw_dependencies to avoid errors during bundle install

```
warning: mingw-w64-x86_64-sqlite3-3.28.0-1 is up to date -- skipping
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
 
current directory:
C:/Ruby25-x64/lib/ruby/gems/2.5.0/bundler/gems/sqlite3-ruby-b6862d8f2542/ext/sqlite3
C:/Ruby25-x64/bin/ruby.exe -r ./siteconf20190709-2332-77lov1.rb extconf.rb
checking for sqlite3.h... yes
checking for pthread_create() in -lpthread... yes
checking for -ldl... no
checking for dlopen()... no
missing function dlopen
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
 
Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=C:/Ruby25-x64/bin/$(RUBY_BASE_NAME)
        --with-sqlcipher
        --without-sqlcipher
        --with-sqlite3-config
        --without-sqlite3-config
        --with-pkg-config
        --without-pkg-config
        --with-sqlcipher
        --without-sqlcipher
        --with-sqlite3-dir
        --without-sqlite3-dir
        --with-sqlite3-include
        --without-sqlite3-include=${sqlite3-dir}/include
        --with-sqlite3-lib
        --without-sqlite3-lib=${sqlite3-dir}/lib
        --with-pthreadlib
        --without-pthreadlib
        --with-dllib
        --without-dllib
```