### PR TITLE
Remove deprecated taint followup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem update --system 2.7.7
+  - gem install bundler -v 1.16.2
 addons:
   apt:
     packages:
@@ -25,6 +25,8 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
 matrix:
   allow_failures:

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -40,11 +40,13 @@ static VALUE rb_sqlite3_open_v2(VALUE self, VALUE file, VALUE mode, VALUE zvfs)
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
 
+#if defined TAINTING_SUPPORT
 #if defined StringValueCStr
   StringValuePtr(file);
   rb_check_safe_obj(file);
 #else
   Check_SafeStr(file);
+#endif
 #endif
 
       status = sqlite3_open_v2(
@@ -761,11 +763,13 @@ static VALUE rb_sqlite3_open16(VALUE self, VALUE file)
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
 
+#if defined TAINTING_SUPPORT
 #if defined StringValueCStr
   StringValuePtr(file);
   rb_check_safe_obj(file);
 #else
   Check_SafeStr(file);
+#endif
 #endif
 
   status = sqlite3_open16(utf16_string_value_ptr(file), &ctx->db);

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -213,16 +213,16 @@ VALUE sqlite3val2rb(sqlite3_value * val)
       return rb_float_new(sqlite3_value_double(val));
       break;
     case SQLITE_TEXT:
-      return rb_tainted_str_new2((const char *)sqlite3_value_text(val));
+      return rb_str_new2((const char *)sqlite3_value_text(val));
       break;
     case SQLITE_BLOB: {
       /* Sqlite warns calling sqlite3_value_bytes may invalidate pointer from sqlite3_value_blob,
          so we explicitly get the length before getting blob pointer.
-         Note that rb_str_new and rb_tainted_str_new apparently create string with ASCII-8BIT (BINARY) encoding,
+         Note that rb_str_new apparently create string with ASCII-8BIT (BINARY) encoding,
          which is what we want, as blobs are binary
        */
       int len = sqlite3_value_bytes(val);
-      return rb_tainted_str_new((const char *)sqlite3_value_blob(val), len);
+      return rb_str_new((const char *)sqlite3_value_blob(val), len);
       break;
     }
     case SQLITE_NULL:

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -47,6 +47,10 @@ if RbConfig::CONFIG["host_os"] =~ /mswin/
   $CFLAGS << ' -W3'
 end
 
+if RUBY_VERSION < '2.7'
+  $CFLAGS << ' -DTAINTING_SUPPORT'
+end
+
 def asplode missing
   if RUBY_PLATFORM =~ /mingw|mswin/
     abort "#{missing} is missing. Install SQLite3 from " +

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -151,7 +151,7 @@ static VALUE step(VALUE self)
               break;
             case SQLITE_TEXT:
               {
-                VALUE str = rb_tainted_str_new(
+                VALUE str = rb_str_new(
                     (const char *)sqlite3_column_text(stmt, i),
                     (long)sqlite3_column_bytes(stmt, i)
                 );
@@ -163,7 +163,7 @@ static VALUE step(VALUE self)
               break;
             case SQLITE_BLOB:
               {
-                VALUE str = rb_tainted_str_new(
+                VALUE str = rb_str_new(
                     (const char *)sqlite3_column_blob(stmt, i),
                     (long)sqlite3_column_bytes(stmt, i)
                 );

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -105,23 +105,6 @@ class TC_ResultSet < SQLite3::TestCase
     assert_equal hash[1], "foo"
   end
 
-  def test_tainted_results_as_hash
-    @db.results_as_hash = true
-    @result.reset( 1 )
-    row = @result.next
-    row.each do |_, v|
-      assert(v.tainted?) if String === v
-    end
-  end
-
-  def test_tainted_row_values
-    @result.reset( 1 )
-    row = @result.next
-    row.each do |v|
-      assert(v.tainted?) if String === v
-    end
-  end
-
   def test_each
     called = 0
     @result.reset( 1, 2 )

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -198,11 +198,6 @@ module SQLite3
       assert_equal ['foo'], r
     end
 
-    def test_tainted
-      r = @stmt.step
-      assert r.first.tainted?
-    end
-
     def test_step_twice
       assert_not_nil @stmt.step
       assert !@stmt.done?


### PR DESCRIPTION
This is a followup on @kamipo's #273 

It also avoid calling `rb_check_safe_obj` on MRI 2.7. That warning is totally spamming Active Record's test suite.

cc @tenderlove since apparently you're maintainer.

cc @rafaelfranca @Edouard-Chin.

NB: Based on @kamipo's PR I expect half of the CI jobs to fail, I'll try to make them pass by pushing another commit.