### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: ruby
 cache: bundler
 before_install:
-  - gem update --system 2.7.7
-  - gem install bundler -v 1.16.2
+  # rubygems 2.7.8 and greater include bundler
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.10 --no-document
+    elif [ "$rv" \< "2.7" ]; then gem update --system --no-document --conservative
+    fi
+  - ruby -v && gem --version && bundle version
+
 addons:
   apt:
     packages:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "mini_portile", "~>0.6.2", :group => [:development, :test]
 gem "hoe-bundler", "~>1.0", :group => [:development, :test]
 gem "hoe-gemspec", "~>1.0", :group => [:development, :test]
 gem "rdoc", ">=4.0", "<6", :group => [:development, :test]
-gem "hoe", "~>3.17", :group => [:development, :test]
+
+# hoe versions >= 3.19.0 are incompatible with Ruby 2.0 and earlier,
+# but the gemspec does not indicate so...
+gem "hoe", (RUBY_VERSION < "2.1" ? "3.18.1" : "~>3.20"), :group => [:development, :test]
 
 # vim: syntax=ruby


### PR DESCRIPTION
This shows that CI is working for the current master.  The main fix is in .travis.yml.

The fix in the gemfile is due to hoe not having a `required_ruby_version` in its gemspec, as the last two releases are incompatible with Ruby 1.9.3 & 2.0. I believe it cannot be added to the code for `rake bundler:gemfile`, so it's a temp fix.

Opened an issue in hoe for it this morning.
