### PR TITLE
Add GitHub Actions for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,27 @@
+name: windows
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '9.9.x', '2.6.x', '2.5.x', '2.4.x' ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Load Ruby, update gcc
+        uses: MSP-Greg/actions-ruby@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          base: update
+          mingw: sqlite3
+      - name: Install dependencies
+        run: |
+          gem update --system --no-document --conservative
+          bundle install --jobs 4 --retry 3
+      - name: compile
+        run:  rake compile:msys2
+      - name: test
+        run:  rake test

--- a/rakelib/native.rake
+++ b/rakelib/native.rake
@@ -51,6 +51,9 @@ RUBY_EXTENSION = Rake::ExtensionTask.new('sqlite3_native', HOE.spec) do |ext|
 end
 
 # ensure things are compiled prior testing
-task :test => [:compile]
-
+if RUBY_PLATFORM =~ /mingw/ then
+  task :test => ["compile:msys2"]
+else
+  task :test => [:compile]
+end
 # vim: syntax=ruby

--- a/rakelib/vendor_sqlite3.rake
+++ b/rakelib/vendor_sqlite3.rake
@@ -37,6 +37,17 @@ if RUBY_PLATFORM =~ /mingw/
   # also prepend DevKit into compilation phase
   Rake::Task["compile"].prerequisites.unshift "devkit", "ports:sqlite3:#{RUBY_PLATFORM}"
   Rake::Task["native"].prerequisites.unshift "devkit", "ports:sqlite3:#{RUBY_PLATFORM}"
+
+  namespace "compile" do
+    desc "Build using MSYS2 sqlite package"
+    task :msys2 do
+      RUBY_EXTENSION.config_options.pop
+      t = Rake::Task["compile"]
+      t.prerequisites.clear
+      t.prerequisites << "devkit" << "compile:#{RUBY_PLATFORM}"
+      t.invoke
+    end
+  end
 end
 
 # trick to test local compilation of sqlite3


### PR DESCRIPTION
1. Add rake compile:msys2 to allow compiling with MSYS2 sqlite3 package

2. Add .github/workflows/windows.yml to run GitHub Actions on Ruby 2.4 thru master on Windows