### PR TITLE
Handle the file argument properly

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -65,6 +65,7 @@ module SQLite3
     def initialize file, options = {}, zvfs = nil
       mode = Constants::Open::READWRITE | Constants::Open::CREATE
 
+      file = file.to_path if file.respond_to? :to_path
       if file.encoding == ::Encoding::UTF_16LE || file.encoding == ::Encoding::UTF_16BE || options[:utf16]
         open16 file
       else

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -47,12 +47,12 @@ module SQLite3
 
 
     def test_filename_to_path
-      assert_equal '', @db.filename
-      pn = Pathname(Tempfile.new('thing').path)
-      @db = SQLite3::Database.new pn
-      assert_equal pn.expand_path.to_s, File.expand_path(@db.filename)
+      tf = Tempfile.new 'thing'
+      pn = Pathname tf.path
+      db = SQLite3::Database.new pn
+      assert_equal pn.expand_path.to_s, File.expand_path(db.filename)
     ensure
-      pn.unlink if pn.exist?
+      tf.close! if tf
     end
 
 

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -45,6 +45,17 @@ module SQLite3
       tf.unlink if tf
     end
 
+
+    def test_filename_to_path
+      assert_equal '', @db.filename
+      pn = Pathname(Tempfile.new('thing').path)
+      @db = SQLite3::Database.new pn
+      assert_equal pn.expand_path.to_s, File.expand_path(@db.filename)
+    ensure
+      pn.unlink if pn.exist?
+    end
+
+
     def test_error_code
       begin
         db.execute 'SELECT'


### PR DESCRIPTION
The argument is a file *path* but is called *file* and yet it's treated as a string.
If passed an actual File or a Pathname it will be properly handled.