### PR TITLE
Fix link to sqlite.org page on compilation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,7 +66,7 @@ Note that this module is only compatible with SQLite 3.6.16 or newer.
 == Compilation and Installation
 
 Install SQLite3, enabling the option SQLITE_ENABLE_COLUMN_METADATA (see
-www.sqlite.org/compile.html for details).
+{www.sqlite.org/compile.html}[https://www.sqlite.org/compile.html] for details).
 
 Then do the following:
 


### PR DESCRIPTION
The partial URL was rendered incorrectly as https://github.com/sparklemotion/sqlite3-ruby/blob/master/www.sqlite.org/compile.html (which leads to a 404 Not Found error on github.com).

I preserved the original look of the documentation (partial URL is displayed with full link href), but the text could be changed to something like "official sqlite compile instructions" or something else that is descriptive.