### PR TITLE
fix tests with latest dependencies

### DIFF
--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -281,20 +281,20 @@ module SQLite3
       db = SQLite3::Database.new(':memory:', :results_as_hash => true)
       db.execute("create table foo ( a integer primary key, b text )")
       info = [{
+        "cid"        => 0,
         "name"       => "a",
-        "pk"         => 1,
+        "type"       => "INTEGER",
         "notnull"    => 0,
-        "type"       => "integer",
         "dflt_value" => nil,
-        "cid"        => 0
+        "pk"         => 1
       },
       {
+        "cid"        => 1,
         "name"       => "b",
-        "pk"         => 0,
+        "type"       => "TEXT",
         "notnull"    => 0,
-        "type"       => "text",
         "dflt_value" => nil,
-        "cid"        => 1
+        "pk"         => 0
       }]
       assert_equal info, db.table_info('foo')
     end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -36,9 +36,9 @@ class TC_Database_Integration < SQLite3::TestCase
     @db.transaction do
       @db.execute "create table no_defaults_test ( a integer default 1, b integer )"
       data = @db.table_info( "no_defaults_test" )
-      assert_equal({"name" => "a", "type" => "integer", "dflt_value" => "1", "notnull" => 0, "cid" => 0, "pk" => 0},
+      assert_equal({"cid" => 0, "name" => "a", "type" => "INTEGER", "notnull" => 0, "dflt_value" => "1", "pk" => 0},
         data[0])
-      assert_equal({"name" => "b", "type" => "integer", "dflt_value" => nil, "notnull" => 0, "cid" => 1, "pk" => 0},
+      assert_equal({"cid" => 1, "name" => "b", "type" => "INTEGER", "notnull" => 0, "dflt_value" => nil, "pk" => 0},
         data[1])
     end
   end

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -118,7 +118,7 @@ class TC_ResultSet < SQLite3::TestCase
   end
 
   def test_types
-    assert_equal [ "integer", "text" ], @result.types
+    assert_equal [ "INTEGER", "TEXT" ], @result.types
   end
 
   def test_columns


### PR DESCRIPTION
while trying to re-build the package ruby-sqlite3 for archlinux ( https://archlinux.org/packages/community/x86_64/ruby-sqlite3/ ) I found issues with the tests:

```
DEPRECATED: Please switch readme to hash format for urls.
  Only defining 'home' url.
  This will be removed on or after 2020-10-28.
install -c tmp/x86_64-linux/sqlite3_native/3.0.3/sqlite3_native.so lib/sqlite3/sqlite3_native.so
cp tmp/x86_64-linux/sqlite3_native/3.0.3/sqlite3_native.so tmp/x86_64-linux/stage/lib/sqlite3/sqlite3_native.so
Run options: --seed 30128

# Running:

......................................................................./build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_statement.rb:130:in `test_bind_blob' is calling SQLite3::ResultSet::ArrayWithTypesAndFields#types.  This method will be removed in
sqlite3 version 2.0.0, please call the `types` method on the SQLite3::ResultSet
object that created this object
.............................................F......................................................./build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_database.rb:93:in `test_execute_with_type_translation_and_hash' is calling SQLite3::Database#type_translation=
SQLite3::Database#type_translation= is deprecated and will be removed
in version 2.0.0.
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:75:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:75:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:77:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:78:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:106:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
........../build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_database.rb:87:in `test_get_first_row_with_type_translation_and_hash_results' is calling SQLite3::Database#type_translation=
SQLite3::Database#type_translation= is deprecated and will be removed
in version 2.0.0.
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:75:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:75:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:77:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:78:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:86:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:92:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:97:in `block in register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/translator.rb:106:in `register_default_translators' is calling `add_translator`.
Built in translators are deprecated and will be removed in version 2.0.0
...F.........................................................F/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/resultset.rb:65:in `[]' is calling SQLite3::ResultSet::HashWithTypesAndFields#fields.  This method will be removed in
sqlite3 version 2.0.0, please call the `columns` method on the SQLite3::ResultSet
object that created this object
/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/lib/sqlite3/resultset.rb:65:in `[]' is calling SQLite3::ResultSet::HashWithTypesAndFields#fields.  This method will be removed in
sqlite3 version 2.0.0, please call the `columns` method on the SQLite3::ResultSet
object that created this object
...............S.......

Finished in 3.480121s, 76.7215 runs/s, 126.1450 assertions/s.

  1) Failure:
TC_Database_Integration#test_table_info_without_defaults_for_version_3_3_8_and_higher [/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_integration.rb:39]:
--- expected
+++ actual
@@ -1 +1 @@
-{"name"=>"a", "type"=>"integer", "dflt_value"=>"1", "notnull"=>0, "cid"=>0, "pk"=>0}
+{"cid"=>0, "name"=>"a", "type"=>"INTEGER", "notnull"=>0, "dflt_value"=>"1", "pk"=>0}


  2) Failure:
SQLite3::TestDatabase#test_table_info [/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_database.rb:288]:
--- expected
+++ actual
@@ -1 +1 @@
-[{"name"=>"a", "pk"=>1, "notnull"=>0, "type"=>"integer", "dflt_value"=>nil, "cid"=>0}, {"name"=>"b", "pk"=>0, "notnull"=>0, "type"=>"text", "dflt_value"=>nil, "cid"=>1}]
+[{"cid"=>0, "name"=>"a", "type"=>"INTEGER", "notnull"=>0, "dflt_value"=>nil, "pk"=>1}, {"cid"=>1, "name"=>"b", "type"=>"TEXT", "notnull"=>0, "dflt_value"=>nil, "pk"=>0}]


  3) Failure:
TC_ResultSet#test_types [/build/ruby-sqlite3/src/sqlite3-ruby-1.4.2/test/test_integration_resultset.rb:121]:
Expected: ["integer", "text"]
  Actual: ["INTEGER", "TEXT"]

267 runs, 439 assertions, 3 failures, 0 errors, 1 skips
```

The changes in this PR fix these issues.