### PR TITLE
version bump to v1.4.3

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,13 @@
-=== 1.4.2
+=== 1.4.3 (2022-05-25)
+
+* Enhancements
+  * Disable non-standard support for double-quoted string literals via the `:strict` option. [#317] (Thank you, @casperisfine!)
+  * Column type names are now explicitly downcased on platforms where they may have been in shoutcaps. [#315] (Thank you, @petergoldstein!)
+  * Support File or Pathname arguments to `Database.new`. [#283] (Thank you, @yb66!)
+  * Support building on MSVC. [#285] (Thank you, @jmarrec!)
+
+
+=== 1.4.2 (2019-12-18)
 
 * Travis: Drop unused setting "sudo: false"
 * The taint mechanism will be deprecated in Ruby 2.7

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -1,12 +1,12 @@
 module SQLite3
 
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 
   module VersionProxy
 
     MAJOR = 1
     MINOR = 4
-    TINY  = 2
+    TINY  = 3
     BUILD = nil
 
     STRING = [ MAJOR, MINOR, TINY, BUILD ].compact.join( "." )


### PR DESCRIPTION
@tenderlove @larskanis can one of you please merge and cut a release if this is satisfactory? I don't have rubygems.org permissions.

@casperisfine has asked for a release to address https://github.com/rails/rails/pull/45101 (see https://github.com/sparklemotion/sqlite3-ruby/pull/317 for context).