### PR TITLE
Add missing semicolon

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -79,7 +79,7 @@ static VALUE rb_sqlite3_disable_quirk_mode(VALUE self)
 
   return Qtrue;
 #else
-  return Qfalse
+  return Qfalse;
 #endif
 }
 


### PR DESCRIPTION
Fixes #323 

The build fails on the `ruby:2.7.5-buster` Docker image (and, presumably, other Linux distros using the same build chain) due to a missing semicolon.  For some reason, the build does _not_ fail on macOS.

Adding this semicolon allows the build to pass on the `ruby:2.7.5-buster` image, and it still passes on macOS as well.