### PR TITLE
ci: cover when strict mode is not available

### DIFF
--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -63,3 +63,13 @@ jobs:
         run:  bundle exec rake compile:msys2
       - name: test
         run:  bundle exec rake test
+
+  ubuntu:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:2.7.5-buster # old enough to not support SQLITE_DBCONFIG_DQS_DDL
+    steps:
+      - uses: actions/checkout@v3
+      - run: bundle install
+      - run: bundle exec rake compile
+      - run: bundle exec rake test

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,13 @@
-=== 1.4.2
+=== 1.4.3 (2022-05-25)
+
+* Enhancements
+  * Disable non-standard support for double-quoted string literals via the `:strict` option. [#317] (Thank you, @casperisfine!)
+  * Column type names are now explicitly downcased on platforms where they may have been in shoutcaps. [#315] (Thank you, @petergoldstein!)
+  * Support File or Pathname arguments to `Database.new`. [#283] (Thank you, @yb66!)
+  * Support building on MSVC. [#285] (Thank you, @jmarrec!)
+
+
+=== 1.4.2 (2019-12-18)
 
 * Travis: Drop unused setting "sudo: false"
 * The taint mechanism will be deprecated in Ruby 2.7

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -1,12 +1,12 @@
 module SQLite3
 
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 
   module VersionProxy
 
     MAJOR = 1
     MINOR = 4
-    TINY  = 2
+    TINY  = 3
     BUILD = nil
 
     STRING = [ MAJOR, MINOR, TINY, BUILD ].compact.join( "." )


### PR DESCRIPTION
PR #317 introduced a strict mode option. This option is supported on [Sqlite 3.29.0 and later](https://www.sqlite.org/releaselog/3_29_0.html). We need coverage for older versions of sqlite as a result (see #324).