### PR TITLE
test: skip version string assertion when testing native gems

### DIFF
--- a/test/test_sqlite3.rb
+++ b/test/test_sqlite3.rb
@@ -19,6 +19,7 @@ module SQLite3
     end
 
     def test_version_strings
+      skip if SQLite3::VERSION.include?("test") # see set-version-to-timestamp rake task
       assert_equal(SQLite3::VERSION, SQLite3::VersionProxy::STRING)
     end
   end


### PR DESCRIPTION
The gem-install actions pipeline clobbers the version with a timestamp, which is making this test fail in CI.