### PR TITLE
Fixes for Windows mswin & sqlcipher 

### DIFF
--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -84,11 +84,8 @@ jobs:
         include:
           - os: "windows-2022"
             ruby: "mingw"
-          # # I'm struggling to build against sqlcipher on mswin.
-          # # find_header can't find sqlite3.h
-          # # patches welcome from anyone who needs this functionality and can make it work.
-          # - os: "windows-2022"
-          #   ruby: "mswin"
+          - os: "windows-2022"
+            ruby: "mswin"
     runs-on: ${{matrix.os}}
     steps:
       - if: matrix.os == 'windows-2022'
@@ -104,6 +101,6 @@ jobs:
           apt-get: "libsqlcipher-dev"
           brew: "sqlcipher"
           mingw: "sqlcipher"
-          # vcpkg: "sqlcipher" # see above
+          vcpkg: "sqlcipher"
       - run: bundle exec rake compile -- --with-sqlcipher
       - run: bundle exec rake test

--- a/ext/sqlite3/sqlite3_ruby.h
+++ b/ext/sqlite3/sqlite3_ruby.h
@@ -21,8 +21,11 @@
 #define SQLITE3_UTF8_STR_NEW2(_obj) \
     (rb_enc_associate_index(rb_str_new2(_obj), rb_utf8_encindex()))
 
-
-#include <sqlite3.h>
+#ifdef USING_SQLCIPHER_INC_SUBDIR
+#  include <sqlcipher/sqlite3.h>
+#else
+#  include <sqlite3.h>
+#endif
 
 #ifndef HAVE_TYPE_SQLITE3_INT64
 typedef sqlite_int64 sqlite3_int64;


### PR DESCRIPTION
Changing the vcpkg input from "sqlcipher" to "sqlite3 sqlcipher" seems to allow compile & test to pass?  Not.sure.

Also, ci log for 'bundle exec rake test' shows:
```
info: sqlite3-ruby version: 1.5.0.rc1/1.5.0.rc1
info: sqlite3 version: 3.39.1/3.37.2
info: sqlcipher?: true
info: threadsafe?: true
```
Not sure what 'sqlite3 version: 3.39.1/3.37.2' is about?

Lastly, CI is ran on Windows 'mingw', which is a Ruby head build, 'ucrt' is also available...  Didn't change.