### PR TITLE
test: assert compiled and loaded versions of sqlite3 are the same

### DIFF
--- a/test/test_sqlite3.rb
+++ b/test/test_sqlite3.rb
@@ -22,5 +22,9 @@ module SQLite3
       skip if SQLite3::VERSION.include?("test") # see set-version-to-timestamp rake task
       assert_equal(SQLite3::VERSION, SQLite3::VersionProxy::STRING)
     end
+
+    def test_compiled_version_and_loaded_version
+      assert_equal(SQLite3::SQLITE_VERSION, SQLite3::SQLITE_LOADED_VERSION)
+    end
   end
 end


### PR DESCRIPTION
Let's assert on this to make sure that CI is testing what we think it's testing.

I have reason to believe (as part of an investigation into #332) that on macos using system libraries, something funky is going on. And it's not obvious to me what it is.
