### PR TITLE
Fix utf16_string_value_ptr() for TruffleRuby

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -31,7 +31,7 @@ static char *
 utf16_string_value_ptr(VALUE str)
 {
   StringValue(str);
-  rb_str_buf_cat(str, "\x00", 1L);
+  rb_str_buf_cat(str, "\x00\x00", 2L);
   return RSTRING_PTR(str);
 }
 


### PR DESCRIPTION
* TruffleRuby uses TruffleString which requires all UTF-16 strings to
  always have an even bytesize.
* The code here ensures the UTF-16 string always ends up with 2 \x00
  bytes, so append them explicitly to have an even bytesize instead of
  relying on RSTRING_PTR() adding the second \x00 byte.
* Fixes https://github.com/oracle/truffleruby/issues/2704

This fixes the CI on TruffleRuby.