### PR TITLE
test: assert compiled and loaded versions of sqlite3 are the same, update sqlite3-ruby.yml

### DIFF
--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -1,3 +1,5 @@
+# for Actions OS info, see https://github.com/actions/runner-images#available-images
+
 name: test suite
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
@@ -20,29 +22,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-2022"]
+        os: [ubuntu-latest, macos-latest, windows-2022]
+        # use quotes for versions, otherwise "3.0" -> "3", "2.10" -> "2.1"
         ruby: ["3.1", "3.0", "2.7", "2.6"]
-        lib: ["system", "packaged"]
+        lib: [system, packaged]
         include:
-          - os: "ubuntu-latest"
-            ruby: "truffleruby-head"
-            lib: "packaged"
-
-          - os: "ubuntu-22.04"
-            ruby: "head"
-            lib: "packaged"
-
-          - os: "ubuntu-22.04"
-            ruby: "head"
-            lib: "system"
-
-          - os: "windows-2022"
-            ruby: "ucrt"
-            lib: "system"
-
-          - os: "windows-2022"
-            ruby: "mswin"
-            lib: "system"
+          - { os: ubuntu-latest, ruby: truffleruby-head, lib: packaged }
+          - { os: ubuntu-22.04 , ruby: head            , lib: packaged }
+          - { os: ubuntu-22.04 , ruby: head            , lib: system   }
+          - { os: windows-2022 , ruby: ucrt            , lib: system   }
+          - { os: windows-2022 , ruby: mswin           , lib: system   }
 
     runs-on: ${{matrix.os}}
     steps:
@@ -56,10 +45,10 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
-          apt-get: "libsqlite3-dev"
-          brew: "sqlite3"
-          mingw: "sqlite3"
-          vcpkg: "sqlite3"
+          apt-get: libsqlite3-dev
+          brew: sqlite3
+          mingw: sqlite3
+          vcpkg: sqlite3
       - if: matrix.lib == 'packaged'
         uses: actions/cache@v3
         with:
@@ -91,13 +80,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-2022"]
+        os: [ubuntu-latest, macos-latest, windows-2022]
+        # use quotes for versions, otherwise "3.0" -> "3", "2.10" -> "2.1"
         ruby: ["3.1", "2.6"] # oldest and newest
         include:
-          - os: "windows-2022"
-            ruby: "mingw"
-          - os: "windows-2022"
-            ruby: "mswin"
+          - { os: windows-2022, ruby: mingw }
+          - { os: windows-2022, ruby: mswin }
     runs-on: ${{matrix.os}}
     steps:
       - if: matrix.os == 'windows-2022'
@@ -110,9 +98,9 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
-          apt-get: "libsqlcipher-dev"
-          brew: "sqlcipher"
-          mingw: "sqlcipher"
-          vcpkg: "sqlcipher"
+          apt-get: libsqlcipher-dev
+          brew: sqlcipher
+          mingw: sqlcipher
+          vcpkg: sqlcipher
       - run: bundle exec rake compile -- --with-sqlcipher
       - run: bundle exec rake test

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -26,21 +26,24 @@ jobs:
         include:
           - os: "ubuntu-latest"
             ruby: "truffleruby-head"
-          - os: "ubuntu-latest"
+            lib: "packaged"
+
+          - os: "ubuntu-22.04"
             ruby: "head"
+            lib: "packaged"
+
+          - os: "ubuntu-22.04"
+            ruby: "head"
+            lib: "system"
+
           - os: "windows-2022"
-            ruby: "mingw"
-            sys: "enable"
-          - os: "windows-2022"
-            ruby: "mingw"
-            sys: "disable"
+            ruby: "ucrt"
+            lib: "system"
+
           - os: "windows-2022"
             ruby: "mswin"
-            sys: "enable"
-          - lib: "system"
-            sys: "enable"
-          - lib: "packaged"
-            sys: "disable"
+            lib: "system"
+
     runs-on: ${{matrix.os}}
     steps:
       - if: matrix.os == 'windows-2022'
@@ -62,7 +65,16 @@ jobs:
         with:
           path: ports
           key: ports-${{matrix.os}}-${{hashFiles('ext/sqlite3/extconf.rb')}}
-      - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
+      
+      - run: bundle exec rake compile -- --disable-system-libraries
+        if: matrix.lib == 'packaged'
+
+      - run: bundle exec rake compile -- --enable-system-libraries
+        if: matrix.lib == 'system' && !startsWith(matrix.os, 'macos')
+
+      - run: bundle exec rake compile -- --enable-system-libraries --with-opt-dir=$(brew --prefix sqlite3)
+        if: matrix.lib == 'system' && startsWith(matrix.os, 'macos')
+
       - run: bundle exec rake test
 
   old_sqlite3:

--- a/test/test_sqlite3.rb
+++ b/test/test_sqlite3.rb
@@ -22,5 +22,9 @@ module SQLite3
       skip if SQLite3::VERSION.include?("test") # see set-version-to-timestamp rake task
       assert_equal(SQLite3::VERSION, SQLite3::VersionProxy::STRING)
     end
+
+    def test_compiled_version_and_loaded_version
+      assert_equal(SQLite3::SQLITE_VERSION, SQLite3::SQLITE_LOADED_VERSION)
+    end
   end
 end


### PR DESCRIPTION
Similar to PR #333, adds a test to verify that compile & runtime sqlite3 versions are the same.

From watching Puma & EventMachine (both compile with OpenSSL), macOS has issues when using brew packages, the solution here is to use `--with-opt-dir=$(brew --prefix sqlite3)` when compiling.

Third comment can be removed, it just contains reformatting of the Actions yaml...

Failure with TruffleRuby-head, see PR #334 for info.  It is a recent failure.
