### PR TITLE
perf: use -O2 compiler optimizations

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -51,7 +51,11 @@ module Sqlite3
         minimal_recipe.tap do |recipe|
           recipe.configure_options += ["--enable-shared=no", "--enable-static=yes"]
           ENV.to_h.tap do |env|
-            env["CFLAGS"] = [env["CFLAGS"], "-fPIC"].join(" ") # needed for linking the static library into a shared library
+            additional_cflags = [
+              "-fPIC", # needed for linking the static library into a shared library
+              "-O2", # see https://github.com/sparklemotion/sqlite3-ruby/issues/335 for some benchmarks
+            ]
+            env["CFLAGS"] = [env["CFLAGS"], additional_cflags].flatten.join(" ")
             recipe.configure_options += env.select { |k,v| ENV_ALLOWLIST.include?(k) }
                                            .map { |key, value| "#{key}=#{value.strip}" }
           end


### PR DESCRIPTION
@Watson1978 pointed out in #335 that the 1.5.0.rc1 performance was worse than 1.4.4. At least part of the reason for this is that we didn't turn on compiler optimizations in 1.5.0.rc1.

This should improve the situation for both the precompiled native and the vanilla gems.
