### PR TITLE
rb_gc_register_address() must be called after the variable was assigned

### DIFF
--- a/ext/sqlite3/aggregator.c
+++ b/ext/sqlite3/aggregator.c
@@ -269,6 +269,6 @@ rb_sqlite3_aggregator_init(void)
   cAggregatorWrapper = rb_funcall(rb_cClass, rb_intern("new"), 0);
   cAggregatorInstance = rb_funcall(rb_cClass, rb_intern("new"), 0);
 
-  rb_gc_register_address(&cAggregatorWrapper);
-  rb_gc_register_address(&cAggregatorInstance);
+  rb_gc_register_mark_object(cAggregatorWrapper);
+  rb_gc_register_mark_object(cAggregatorInstance);
 }

--- a/ext/sqlite3/aggregator.c
+++ b/ext/sqlite3/aggregator.c
@@ -265,9 +265,10 @@ rb_sqlite3_define_aggregator2(VALUE self, VALUE aggregator, VALUE ruby_name)
 void
 rb_sqlite3_aggregator_init(void)
 {
-  rb_gc_register_address(&cAggregatorWrapper);
-  rb_gc_register_address(&cAggregatorInstance);
   /* rb_class_new generatos class with undefined allocator in ruby 1.9 */
   cAggregatorWrapper = rb_funcall(rb_cClass, rb_intern("new"), 0);
   cAggregatorInstance = rb_funcall(rb_cClass, rb_intern("new"), 0);
+
+  rb_gc_register_address(&cAggregatorWrapper);
+  rb_gc_register_address(&cAggregatorInstance);
 }

--- a/ext/sqlite3/aggregator.c
+++ b/ext/sqlite3/aggregator.c
@@ -267,8 +267,8 @@ rb_sqlite3_aggregator_init(void)
 {
   /* rb_class_new generatos class with undefined allocator in ruby 1.9 */
   cAggregatorWrapper = rb_funcall(rb_cClass, rb_intern("new"), 0);
-  cAggregatorInstance = rb_funcall(rb_cClass, rb_intern("new"), 0);
-
   rb_gc_register_mark_object(cAggregatorWrapper);
+
+  cAggregatorInstance = rb_funcall(rb_cClass, rb_intern("new"), 0);
   rb_gc_register_mark_object(cAggregatorInstance);
 }


### PR DESCRIPTION
* Otherwise the GC might read the variable when it is not pointing to a Ruby object yet.
* TruffleRuby also assumes it can read the pointer when
  rb_gc_register_address() is called: https://github.com/oracle/truffleruby/issues/2720