### PR TITLE
ci: build against edge sqlite

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,23 @@
+name: upstream
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
+
+jobs:
+  sqlite-head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git clone --depth=1 https://github.com/sqlite/sqlite
+          git -C sqlite log -n1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - run: bundle exec rake compile -- --with-sqlite-source-dir=${GITHUB_WORKSPACE}/sqlite
+      - run: bundle exec rake test

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -126,9 +126,13 @@ module Sqlite3
 
       def minimal_recipe
         MiniPortile.new(libname, sqlite3_config[:version]).tap do |recipe|
-          recipe.files = sqlite3_config[:files]
-          recipe.target = File.join(package_root_dir, "ports")
-          recipe.patch_files = Dir[File.join(package_root_dir, "patches", "*.patch")].sort
+          if sqlite_source_dir
+            recipe.source_directory = sqlite_source_dir
+          else
+            recipe.files = sqlite3_config[:files]
+            recipe.target = File.join(package_root_dir, "ports")
+            recipe.patch_files = Dir[File.join(package_root_dir, "patches", "*.patch")].sort
+          end
         end
       end
 
@@ -157,6 +161,10 @@ module Sqlite3
         enable_config("cross-build")
       end
 
+      def sqlite_source_dir
+        arg_config("--with-sqlite-source-dir")
+      end
+
       def download
         minimal_recipe.download
       end
@@ -177,6 +185,9 @@ module Sqlite3
                 --with-sqlcipher
                     Use libsqlcipher instead of libsqlite3.
                     (Implies `--enable-system-libraries`.)
+
+                --with-sqlite-source-dir=DIRECTORY
+                    (dev only) Build sqlite from the source code in DIRECTORY
 
                 --help
                     Display this message.


### PR DESCRIPTION
Sqlite 3.34.0 is going to come out soon, and I'd like to be able to build against upstream edge.

This PR does two things:

- add a `--with-sqlite-source-dir=` option to extconf.rb
- add a new CI pipeline that uses that option to build against edge sqlite

