### PR TITLE
ci: pin psych until CI platforms have libyaml-dev

### DIFF
--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -111,6 +111,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake-compiler", "~> 1.2.0")
   s.add_development_dependency("rake-compiler-dock", "~> 1.2.1")
   s.add_development_dependency("rdoc", ">= 4.0", "< 7")
+  s.add_development_dependency("psych", "~> 4.0") # psych 5 doesn't build on some CI platforms yet
 
   s.extensions << "ext/sqlite3/extconf.rb"
 end


### PR DESCRIPTION
Psych 5 requires libyaml-dev, which isn't installed in github actions or setup-ruby.

See https://github.com/ruby/setup-ruby/issues/409