### PR TITLE
ext: export only Init_sqlite3_native

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -127,6 +127,7 @@ void init_sqlite3_constants()
 #endif
 }
 
+RUBY_FUNC_EXPORTED
 void Init_sqlite3_native()
 {
   /*


### PR DESCRIPTION
This works around new Darwin Ruby 3.2 symbol resolution issues, but also follows best practices around shipping shared libraries.

The result is that the only public (exported) symbol in the extension is `Init_sqlite3_native`, regardless of what platform or version of Ruby you're on.

See https://github.com/rake-compiler/rake-compiler-dock/issues/87 for lots of context.