### PR TITLE
dep: update packaged sqlite3 to 3.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sqlite3-ruby Changelog
 
+## next / unreleased
+
+### Dependencies
+
+* Vendored sqlite is updated to [v3.41.0](https://sqlite.org/releaselog/3_41_0.html).
+
+
 ## 1.6.0 / 2023-01-13
 
 ### Ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,15 @@ As a prerequisite please make sure you have `docker` correctly installed, so tha
 Run `bin/build-gems` which will package gems for all supported platforms, and run some basic sanity tests on those packages using `bin/test-gem-set` and `bin/test-gem-file-contents`.
 
 
+## Updating the version of libsqlite3
+
+Update `/dependencies.yml` to reflect:
+
+- the version of libsqlite3
+- the URL from which to download
+- the checksum of the file, which will need to be verified manually (see comments in that file)
+
+
 ## Making a release
 
 A quick checklist:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,14 +2,13 @@
 :sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3400100.tar.gz
-  # 3136db4bcd9e9e1e485c291380a3d86f0f21cae0eff9f714c0ef4821e2e5cdf7  ports/archives/sqlite-autoconf-3400100.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3410000.tar.gz
+  # d783ab44a2b44394331d392b8b8d4d2ea4964cbb2befc7c6c649bcfbdb3c9ffe  ports/archives/sqlite-autoconf-3410000.tar.gz
   #
-  # juno in sqlite3-ruby on  flavorjones-update-sqlite-3.40.1 [$!?] via 💎 v3.1.2
-  # $ sha256sum ports/archives/sqlite-autoconf-3400100.tar.gz
-  # 2c5dea207fa508d765af1ef620b637dcb06572afa6f01f0815bd5bbf864b33d9  ports/archives/sqlite-autoconf-3400100.tar.gz
+  # $ sha256sum ports/archives/sqlite-autoconf-3410000.tar.gz
+  # 49f77ac53fd9aa5d7395f2499cb816410e5621984a121b858ccca05310b05c70  ports/archives/sqlite-autoconf-3410000.tar.gz
   #
-  :version: "3.40.1"
+  :version: "3.41.0"
   :files:
-    - :url: "https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz"
-      :sha256: "2c5dea207fa508d765af1ef620b637dcb06572afa6f01f0815bd5bbf864b33d9"
+    - :url: "https://sqlite.org/2023/sqlite-autoconf-3410000.tar.gz"
+      :sha256: "49f77ac53fd9aa5d7395f2499cb816410e5621984a121b858ccca05310b05c70"


### PR DESCRIPTION
https://sqlite.org/releaselog/3_41_0.html

From the release announcement:

> This is a routine maintenance release.  Upgrading is optional.
