### PR TITLE
ci: fix the build and run it weekly to prevent bitrot

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -84,9 +84,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
+          brew: sqlite3 pkg-config
       - uses: actions/download-artifact@v3
         with:
           name: cruby-gem

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -4,6 +4,8 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
   push:
     branches:
       - master

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -45,7 +45,7 @@ jobs:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
           apt-get: libsqlite3-dev
-          brew: sqlite3
+          brew: sqlite3 pkg-config
           mingw: sqlite3
           vcpkg: sqlite3
       - if: matrix.lib == 'packaged'
@@ -112,7 +112,7 @@ jobs:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
           apt-get: libsqlcipher-dev
-          brew: sqlcipher
+          brew: sqlcipher pkg-config
           mingw: sqlcipher
           vcpkg: sqlcipher
       - run: bundle exec rake compile -- --with-sqlcipher

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -6,6 +6,8 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
   push:
     branches:
       - master

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -5,7 +5,7 @@ concurrency:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
+    - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
 
 jobs:
   sqlite-head:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,7 @@ test_script:
 
 environment:
   matrix:
+    - ruby_version: "32"
     - ruby_version: "31"
     - ruby_version: "30"
     - ruby_version: "27"
-    - ruby_version: "26"
-    - ruby_version: "25"

--- a/ext/sqlite3/backup.c
+++ b/ext/sqlite3/backup.c
@@ -150,7 +150,7 @@ static VALUE pagecount(VALUE self)
   return INT2NUM(sqlite3_backup_pagecount(ctx->p));
 }
 
-void init_sqlite3_backup()
+void init_sqlite3_backup(void)
 {
 #if 0
   VALUE mSqlite3 = rb_define_module("SQLite3");

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -800,7 +800,7 @@ static VALUE rb_sqlite3_open16(VALUE self, VALUE file)
   return INT2NUM(status);
 }
 
-void init_sqlite3_database()
+void init_sqlite3_database(void)
 {
 #if 0
   VALUE mSqlite3 = rb_define_module("SQLite3");

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -82,7 +82,7 @@ static VALUE threadsafe_p(VALUE UNUSED(klass))
   return INT2NUM(sqlite3_threadsafe());
 }
 
-void init_sqlite3_constants()
+void init_sqlite3_constants(void)
 {
   VALUE mSqlite3Constants;
   VALUE mSqlite3Open;
@@ -128,7 +128,7 @@ void init_sqlite3_constants()
 }
 
 RUBY_FUNC_EXPORTED
-void Init_sqlite3_native()
+void Init_sqlite3_native(void)
 {
   /*
    * SQLite3 is a wrapper around the popular database

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -418,7 +418,7 @@ static VALUE database_name(VALUE self, VALUE index)
 
 #endif
 
-void init_sqlite3_statement()
+void init_sqlite3_statement(void)
 {
   cSqlite3Statement = rb_define_class_under(mSqlite3, "Statement", rb_cObject);
 


### PR DESCRIPTION
Three commits:
- avoid compiler warnings about old-style function definitions
- ensure pkg-config is installed on macos CI images (to fix the build)
- run the full test suite weekly
