### PR TITLE
Exposes the `sqlite3_close_v2` function

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -36,6 +36,7 @@ utf16_string_value_ptr(VALUE str)
 }
 
 static VALUE sqlite3_rb_close(VALUE self);
+static VALUE sqlite3_rb_close_v2(VALUE self);
 
 static VALUE rb_sqlite3_open_v2(VALUE self, VALUE file, VALUE mode, VALUE zvfs)
 {
@@ -95,6 +96,26 @@ static VALUE sqlite3_rb_close(VALUE self)
 
   db = ctx->db;
   CHECK(db, sqlite3_close(ctx->db));
+
+  ctx->db = NULL;
+
+  rb_iv_set(self, "-aggregators", Qnil);
+
+  return self;
+}
+
+/* call-seq: db.close
+ *
+ * Closes this database.
+ */
+static VALUE sqlite3_rb_close_v2(VALUE self)
+{
+  sqlite3RubyPtr ctx;
+  sqlite3 * db;
+  Data_Get_Struct(self, sqlite3Ruby, ctx);
+
+  db = ctx->db;
+  CHECK(db, sqlite3_close_v2(ctx->db));
 
   ctx->db = NULL;
 
@@ -813,6 +834,7 @@ void init_sqlite3_database()
   rb_define_private_method(cSqlite3Database, "open16", rb_sqlite3_open16, 1);
   rb_define_method(cSqlite3Database, "collation", collation, 2);
   rb_define_method(cSqlite3Database, "close", sqlite3_rb_close, 0);
+  rb_define_method(cSqlite3Database, "close_v2", sqlite3_rb_close_v2, 0);
   rb_define_method(cSqlite3Database, "closed?", closed_p, 0);
   rb_define_method(cSqlite3Database, "total_changes", total_changes, 0);
   rb_define_method(cSqlite3Database, "trace", trace, -1);

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
-# stub: sqlite3 1.3.13.20180326210955 ruby lib
+# stub: sqlite3 1.4.4 ruby lib
 # stub: ext/sqlite3/extconf.rb
 
 Gem::Specification.new do |s|
   s.name = "sqlite3".freeze
-  s.version = "1.3.13.20180326210955"
+  s.version = "1.4.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.5".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "msys2_mingw_dependencies" => "sqlite3" } if s.respond_to? :metadata=

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -217,6 +217,12 @@ module SQLite3
       assert db.closed?
     end
 
+    def test_close_v2
+      db = SQLite3::Database.new(':memory:')
+      db.close_v2
+      assert db.closed?
+    end
+
     def test_block_closes_self
       thing = nil
       SQLite3::Database.new(':memory:') do |db|


### PR DESCRIPTION
I've been running into this error while closing the DB:
`unable to close due to unfinalized statements or unfinished backups`

I've audited the app, and all statements are finalized.

Looking at the sqlite docs, it looks like `sqlite3_close_v2` might actually be the close function to call:
https://www.sqlite.org/c3ref/close.html

> If sqlite3_close_v2() is called with unfinalized prepared statements, unclosed BLOB handlers, and/or unfinished sqlite3_backups, it returns [SQLITE_OK](https://www.sqlite.org/rescode.html#ok) regardless, but instead of deallocating the database connection immediately, it marks the database connection as an unusable "zombie" and makes arrangements to automatically deallocate the database connection after all prepared statements are finalized, all BLOB handles are closed, and all backups have finished. The sqlite3_close_v2() interface is intended for use with host languages that are garbage collected, and where the order in which destructors are called is arbitrary.

The intent of this PR is two-folds:
- To check whether you are open to exposing the `sqlite3_close_v2` function through the sqlite3 adapter.
- To check whether the implementation looks correct. It clears the allocated memory on the ruby side the same way as `sqlite3_rb_close`. I think it's safe, but looking to get your thoughts.
  - I'm not sure if the test is good enough either, as it seems to just check for memory de-allocation.

If the changes look good, I'm also looking at doing a backport to v1.4.4 if you are open to it.

Thank you. :) 