### PR TITLE
Add a valgrind test task, and clean up resource management in the tests

### DIFF
--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -119,3 +119,16 @@ jobs:
           vcpkg: sqlcipher
       - run: bundle exec rake compile -- --with-sqlcipher
       - run: bundle exec rake test
+
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          apt-get: libsqlite3-dev valgrind
+      - run: bundle install
+      - run: bundle exec rake compile
+      - run: bundle exec rake test:valgrind

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem("minitest", "~> 5.15")
+gem("rake-compiler", "~> 1.2.0")
+gem("rake-compiler-dock", "1.3.0")
+gem("rdoc", ">= 4.0", "< 7")
+gem("psych", "~> 4.0") # psych 5 doesn't build on some CI platforms yet
+
+gem("ruby_memcheck") if Gem::Platform.local.os == "linux"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,7 +1,20 @@
 require "rake/testtask"
-
-Rake::TestTask.new(:test) do |t|
+test_config = lambda do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/test_*.rb"]
+end
+
+Rake::TestTask.new(:test, &test_config)
+
+begin
+  require "ruby_memcheck"
+
+  RubyMemcheck.config(binary_name: "sqlite3_native")
+
+  namespace :test do
+    RubyMemcheck::TestTask.new(:valgrind, &test_config)
+  end
+rescue LoadError => e
+  warn("NOTE: ruby_memcheck is not available in this environment: #{e}")
 end

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -108,11 +108,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mini_portile2", "~> 2.8.0")
 
-  s.add_development_dependency("minitest", "~> 5.15")
-  s.add_development_dependency("rake-compiler", "~> 1.2.0")
-  s.add_development_dependency("rake-compiler-dock", "1.3.0")
-  s.add_development_dependency("rdoc", ">= 4.0", "< 7")
-  s.add_development_dependency("psych", "~> 4.0") # psych 5 doesn't build on some CI platforms yet
-
   s.extensions << "ext/sqlite3/extconf.rb"
 end

--- a/test/test_deprecated.rb
+++ b/test/test_deprecated.rb
@@ -2,8 +2,6 @@ require 'helper'
 
 module SQLite3
   class TestDeprecated < SQLite3::TestCase
-    attr_reader :db
-
     def setup
       super
       @warn_before = $-w
@@ -15,10 +13,13 @@ module SQLite3
     def teardown
       super
       $-w = @warn_before
+      @db.close
     end
 
     def test_query_with_many_bind_params_not_nil
-      assert_equal [[1, 2]], db.query('select ?, ?', 1, 2).to_a
+      rs = @db.query('select ?, ?', 1, 2)
+      assert_equal [[1, 2]], rs.to_a
+      rs.close
     end
 
     def test_execute_with_many_bind_params_not_nil
@@ -26,11 +27,15 @@ module SQLite3
     end
 
     def test_query_with_many_bind_params
-      assert_equal [[nil, 1]], @db.query("select ?, ?", nil, 1).to_a
+      rs = @db.query("select ?, ?", nil, 1)
+      assert_equal [[nil, 1]], rs.to_a
+      rs.close
     end
 
     def test_query_with_nil_bind_params
-      assert_equal [['foo']], @db.query("select 'foo'", nil).to_a
+      rs = @db.query("select 'foo'", nil)
+      assert_equal [['foo']], rs.to_a
+      rs.close
     end
 
     def test_execute_with_many_bind_params

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -11,6 +11,10 @@ module SQLite3
       @db.execute(@create);
     end
 
+    def teardown
+      @db.close
+    end
+
     def test_select_encoding_on_utf_16
       str = "foo"
       utf16 = ([1].pack("I") == [1].pack("N")) ? "UTF-16BE" : "UTF-16LE"
@@ -24,6 +28,7 @@ module SQLite3
         assert_equal 1, stmt.to_a.length
         stmt.reset!
       end
+      stmt.close
     end
 
     def test_insert_encoding
@@ -39,6 +44,7 @@ module SQLite3
         stmt.to_a
         stmt.reset!
       end
+      stmt.close
 
       db.execute('select data from ex').flatten.each do |s|
         assert_equal str, s
@@ -55,6 +61,7 @@ module SQLite3
       stmt = @db.prepare('insert into ex(data) values (?)')
       stmt.bind_param 1, str
       stmt.step
+      stmt.close
 
       Encoding.default_internal = 'EUC-JP'
       string = @db.execute('select data from ex').first.first
@@ -73,6 +80,7 @@ module SQLite3
       stmt = @db.prepare('insert into foo(data) values (?)')
       stmt.bind_param(1, SQLite3::Blob.new(str))
       stmt.step
+      stmt.close
 
       string = @db.execute('select data from foo').first.first
       assert_equal Encoding.find('ASCII-8BIT'), string.encoding
@@ -85,6 +93,7 @@ module SQLite3
       stmt = @db.prepare('insert into foo(data) values (?)')
       stmt.bind_param(1, str.dup.force_encoding("ASCII-8BIT"))
       stmt.step
+      stmt.close
 
       string = @db.execute('select data from foo').first.first
       assert_equal Encoding.find('ASCII-8BIT'), string.encoding
@@ -97,6 +106,7 @@ module SQLite3
       stmt = @db.prepare('insert into foo(data) values (?)')
       stmt.bind_param(1, SQLite3::Blob.new(str))
       stmt.step
+      stmt.close
 
       string = @db.execute('select data from foo').first.first
       assert_equal Encoding.find('ASCII-8BIT'), string.encoding

--- a/test/test_result_set.rb
+++ b/test/test_result_set.rb
@@ -2,29 +2,38 @@ require 'helper'
 
 module SQLite3
   class TestResultSet < SQLite3::TestCase
+    def setup
+      @db = SQLite3::Database.new ':memory:'
+      super
+    end
+
+    def teardown
+      super
+      @db.close
+    end
+
     def test_each_hash
-      db = SQLite3::Database.new ':memory:'
-      db.execute "create table foo ( a integer primary key, b text )"
+      @db.execute "create table foo ( a integer primary key, b text )"
       list = ('a'..'z').to_a
       list.each do |t|
-        db.execute "insert into foo (b) values (\"#{t}\")"
+        @db.execute "insert into foo (b) values (\"#{t}\")"
       end
 
-      rs = db.prepare('select * from foo').execute
+      rs = @db.prepare('select * from foo').execute
       rs.each_hash do |hash|
         assert_equal list[hash['a'] - 1], hash['b']
       end
+      rs.close
     end
 
     def test_next_hash
-      db = SQLite3::Database.new ':memory:'
-      db.execute "create table foo ( a integer primary key, b text )"
+      @db.execute "create table foo ( a integer primary key, b text )"
       list = ('a'..'z').to_a
       list.each do |t|
-        db.execute "insert into foo (b) values (\"#{t}\")"
+        @db.execute "insert into foo (b) values (\"#{t}\")"
       end
 
-      rs = db.prepare('select * from foo').execute
+      rs = @db.prepare('select * from foo').execute
       rows = []
       while row = rs.next_hash
         rows << row
@@ -32,6 +41,7 @@ module SQLite3
       rows.each do |hash|
         assert_equal list[hash['a'] - 1], hash['b']
       end
+      rs.close
     end
   end
 end

--- a/test/test_statement_execute.rb
+++ b/test/test_statement_execute.rb
@@ -8,6 +8,10 @@ module SQLite3
         "CREATE TABLE items (id integer PRIMARY KEY, number integer)")
     end
 
+    def teardown
+      @db.close
+    end
+
     def test_execute_insert
       ps = @db.prepare("INSERT INTO items (number) VALUES (:n)")
       ps.execute('n'=>10)


### PR DESCRIPTION
- use `ruby_memcheck` to invoke valgrind on the test suite to look for leaks and memory errors
- add the valgrind test to CI
- clean up the tests to properly close Database, Statement, and ResultSet objects
