### PR TITLE
Always call sqlite3_finalize in deallocate func

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -6,6 +6,18 @@
 
 VALUE cSqlite3Statement;
 
+static void
+statement_deallocate(void *data)
+{
+    sqlite3StmtRubyPtr s = (sqlite3StmtRubyPtr)data;
+
+    if (s->st) {
+        sqlite3_finalize(s->st);
+    }
+
+    xfree(data);
+}
+
 static size_t
 statement_memsize(const void *data)
 {
@@ -18,7 +30,7 @@ static const rb_data_type_t statement_type = {
     "SQLite3::Backup",
     {
         NULL,
-        RUBY_TYPED_DEFAULT_FREE,
+        statement_deallocate,
         statement_memsize,
     },
     0,

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -89,6 +89,7 @@ Gem::Specification.new do |s|
     "test/test_integration_resultset.rb",
     "test/test_integration_statement.rb",
     "test/test_pragmas.rb",
+    "test/test_resource_cleanup.rb",
     "test/test_result_set.rb",
     "test/test_sqlite3.rb",
     "test/test_statement.rb",

--- a/test/test_resource_cleanup.rb
+++ b/test/test_resource_cleanup.rb
@@ -1,0 +1,27 @@
+require "helper"
+
+module SQLite3
+  # these tests will cause ruby_memcheck to report a leak if we're not cleaning up resources
+  class TestResourceCleanup < SQLite3::TestCase
+    def test_cleanup_unclosed_database_object
+      100.times do
+        SQLite3::Database.new(':memory:')
+      end
+    end
+
+    def test_cleanup_unclosed_statement_object
+      100.times do
+        db = SQLite3::Database.new(':memory:')
+        db.execute('create table foo(text BLOB)')
+        db.prepare('select * from foo')
+      end
+    end
+
+    # def test_cleanup_unclosed_resultset_object
+    #   db = SQLite3::Database.new(':memory:')
+    #   db.execute('create table foo(text BLOB)')
+    #   stmt = db.prepare('select * from foo')
+    #   stmt.execute
+    # end
+  end
+end


### PR DESCRIPTION
Prevents memory leak in the case that `close` is not called before a `ResultSet` is garbage collected.

`close` sets `c->st` to `NULL` immediately after calling `sqlite3_finalize` itself, so there is no double-free risk introduced with this change.