### PR TITLE
dep: update sqlite3 to v3.43.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,13 +2,13 @@
 :sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3420000.tar.gz
-  # 643898e9fcc8f6069bcd47b0e6057221c1ed17bbee57da20d2752c79d91274e8  ports/archives/sqlite-autoconf-3420000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3430000.tar.gz
+  # cc321c7b0a70f87aaefe5d0aa89cdd97b432c3d2d448fa623f20988007c49f34  ports/archives/sqlite-autoconf-3430000.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3420000.tar.gz
-  # 7abcfd161c6e2742ca5c6c0895d1f853c940f203304a0b49da4e1eca5d088ca6  ports/archives/sqlite-autoconf-3420000.tar.gz
+  # $ sha256sum ports/archives/sqlite-autoconf-3430000.tar.gz
+  # 49008dbf3afc04d4edc8ecfc34e4ead196973034293c997adad2f63f01762ae1  ports/archives/sqlite-autoconf-3430000.tar.gz
   #
-  :version: "3.42.0"
+  :version: "3.43.0"
   :files:
-    - :url: "https://sqlite.org/2023/sqlite-autoconf-3420000.tar.gz"
-      :sha256: "7abcfd161c6e2742ca5c6c0895d1f853c940f203304a0b49da4e1eca5d088ca6"
+    - :url: "https://sqlite.org/2023/sqlite-autoconf-3430000.tar.gz"
+      :sha256: "49008dbf3afc04d4edc8ecfc34e4ead196973034293c997adad2f63f01762ae1"

--- a/test/test_integration_statement.rb
+++ b/test/test_integration_statement.rb
@@ -77,10 +77,10 @@ class TC_Statement < SQLite3::TestCase
   def test_bind_param_with_various_types
     @db.transaction do
       @db.execute "create table all_types ( a integer primary key, b float, c string, d integer )"
-      @db.execute "insert into all_types ( b, c, d ) values ( 1.4, 'hello', 68719476735 )"
+      @db.execute "insert into all_types ( b, c, d ) values ( 1.5, 'hello', 68719476735 )"
     end
 
-    assert_equal 1, @db.execute( "select * from all_types where b = ?", 1.4 ).length
+    assert_equal 1, @db.execute( "select * from all_types where b = ?", 1.5 ).length
     assert_equal 1, @db.execute( "select * from all_types where c = ?", 'hello').length
     assert_equal 1, @db.execute( "select * from all_types where d = ?", 68719476735).length
   end


### PR DESCRIPTION
https://sqlite.org/releaselog/3_43_0.html

From the upstream changelog:

> SQLite Release 3.43.0 On 2023-08-24
> * Add support for Contentless-Delete FTS5 Indexes. This is a variety of FTS5 full-text search index that omits storing the content that is being indexed while also allowing records to be deleted.
> * Enhancements to the date and time functions:
>   * Added new time shift modifiers of the form ±YYYY-MM-DD HH:MM:SS.SSS.
>   * Added the timediff() SQL function.
> * Added the octet_length(X) SQL function.
> * Added the sqlite3_stmt_explain() API.
> * Query planner enhancements:
>   * Generalize the LEFT JOIN strength reduction optimization so that it works for RIGHT and FULL JOINs as well. Rename it to OUTER JOIN strength reduction.
>   * Enhance the theorem prover in the OUTER JOIN strength reduction optimization so that it returns fewer false-negatives.
> * Enhancements to the decimal extension:
>   * New function decimal_pow2(N) returns the N-th power of 2 for integer N between -20000 and +20000.
>   * New function decimal_exp(X) works like decimal(X) except that it returns the result in exponential notation - with a "e+NN" at the end.
>   * If X is a floating-point value, then the decimal(X) function now does a full expansion of that value into its exact decimal equivalent.
> * Performance enhancements to JSON processing results in a 2x performance improvement for some kinds of processing on large JSON strings.
> * New makefile target "verify-source" checks to ensure that there are no unintentional changes in the source tree. (Works for canonical source code only - not for precompiled amalgamation tarballs.)
> * Added the SQLITE_USE_SEH compile-time option that enables Structured Exception Handling on Windows while working with the memory-mapped shm file that is part of WAL mode processing. This option is enabled by default when building on Windows using Makefile.msc.
> * The VFS for unix now assumes that the nanosleep() system call is available unless compiled with -DHAVE_NANOSLEEP=0.
