### PR TITLE
some general cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - run: |
           dnf group install -y "C Development Tools and Libraries"
-          dnf install -y ruby ruby-devel
+          dnf install -y ruby ruby-devel libyaml-devel
       - uses: actions/checkout@v3
       - run: bundle install
       - run: bundle exec rake compile -- --disable-system-libraries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ A quick checklist:
 
 - [ ] make sure CI is green!
 - [ ] update `CHANGELOG.md` and `lib/sqlite3/version.rb` including `VersionProxy::{MINOR,TINY}`
-- [ ] create a git tag using a format that matches the pattern `v\d+\.\d+\.\d+`, e.g. `v1.3.13`
 - [ ] run `bin/build-gems` and make sure it completes and all the tests pass
+- [ ] create a git tag using a format that matches the pattern `v\d+\.\d+\.\d+`, e.g. `v1.3.13`
+- [ ] `git push && git push --tags`
 - [ ] `for g in gems/*.gem ; do gem push $g ; done`
 - [ ] create a release at https://github.com/sparklemotion/sqlite3-ruby/releases and include sha2 checksums

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
-gem("minitest", "~> 5.15")
-gem("rake-compiler", "~> 1.2.0")
+gem("minitest", "5.20.0")
+gem("rake-compiler", "1.2.5")
 gem("rake-compiler-dock", "1.3.0")
-gem("rdoc", ">= 4.0", "< 7")
-gem("psych", "~> 4.0") # psych 5 doesn't build on some CI platforms yet
+gem("rdoc", "6.5.0")
+gem("psych", "5.1.0")
 
 gem("ruby_memcheck", "2.1.2") if Gem::Platform.local.os == "linux"

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem("rake-compiler-dock", "1.3.0")
 gem("rdoc", ">= 4.0", "< 7")
 gem("psych", "~> 4.0") # psych 5 doesn't build on some CI platforms yet
 
-gem("ruby_memcheck") if Gem::Platform.local.os == "linux"
+gem("ruby_memcheck", "2.1.2") if Gem::Platform.local.os == "linux"

--- a/bin/build-gems
+++ b/bin/build-gems
@@ -19,7 +19,7 @@ bundle exec rake compile test
 
 # package the gems, including precompiled native
 bundle exec rake clean clobber
-bundle exec rake gem:all
+bundle exec rake -m gem:all
 cp -v pkg/sqlite3*.gem gems
 
 # test those gem files!

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -127,7 +127,7 @@ static VALUE total_changes(VALUE self)
   Data_Get_Struct(self, sqlite3Ruby, ctx);
   REQUIRE_OPEN_DB(ctx);
 
-  return INT2NUM((long)sqlite3_total_changes(ctx->db));
+  return INT2NUM(sqlite3_total_changes(ctx->db));
 }
 
 static void tracefunc(void * data, const char *sql)
@@ -168,7 +168,7 @@ static int rb_sqlite3_busy_handler(void * ctx, int count)
 {
   VALUE self = (VALUE)(ctx);
   VALUE handle = rb_iv_get(self, "@busy_handler");
-  VALUE result = rb_funcall(handle, rb_intern("call"), 1, INT2NUM((long)count));
+  VALUE result = rb_funcall(handle, rb_intern("call"), 1, INT2NUM(count));
 
   if(Qfalse == result) return 0;
 
@@ -413,7 +413,7 @@ static VALUE errcode_(VALUE self)
   Data_Get_Struct(self, sqlite3Ruby, ctx);
   REQUIRE_OPEN_DB(ctx);
 
-  return INT2NUM((long)sqlite3_errcode(ctx->db));
+  return INT2NUM(sqlite3_errcode(ctx->db));
 }
 
 /* call-seq: complete?(sql)

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -348,7 +348,7 @@ static VALUE column_count(VALUE self)
   Data_Get_Struct(self, sqlite3StmtRuby, ctx);
   REQUIRE_OPEN_STMT(ctx);
 
-  return INT2NUM((long)sqlite3_column_count(ctx->st));
+  return INT2NUM(sqlite3_column_count(ctx->st));
 }
 
 /* call-seq: stmt.column_name(index)
@@ -397,7 +397,7 @@ static VALUE bind_parameter_count(VALUE self)
   Data_Get_Struct(self, sqlite3StmtRuby, ctx);
   REQUIRE_OPEN_STMT(ctx);
 
-  return INT2NUM((long)sqlite3_bind_parameter_count(ctx->st));
+  return INT2NUM(sqlite3_bind_parameter_count(ctx->st));
 }
 
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -116,9 +116,7 @@ module SQLite3
 
     def type_translation= value # :nodoc:
       warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling SQLite3::Database#type_translation=
-SQLite3::Database#type_translation= is deprecated and will be removed
-in version 2.0.0.
+#{caller[0]} is calling `SQLite3::Database#type_translation=` which is deprecated and will be removed in version 2.0.0.
       eowarn
       @type_translator  = make_type_translator value
       @type_translation = value
@@ -189,9 +187,7 @@ in version 2.0.0.
         end
 
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling SQLite3::Database#execute with nil or multiple bind params
-without using an array.  Please switch to passing bind parameters as an array.
-Support for bind parameters as *args will be removed in 2.0.0.
+#{caller[0]} is calling `SQLite3::Database#execute` with nil or multiple bind params without using an array.  Please switch to passing bind parameters as an array. Support for bind parameters as *args will be removed in 2.0.0.
         eowarn
       end
 
@@ -248,9 +244,7 @@ Support for bind parameters as *args will be removed in 2.0.0.
       unless [Array, Hash].include?(bind_vars.class)
         bind_vars = [bind_vars]
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling SQLite3::Database#execute_batch with bind parameters
-that are not a list of a hash.  Please switch to passing bind parameters as an
-array or hash. Support for this behavior will be removed in version 2.0.0.
+#{caller[0]} is calling `SQLite3::Database#execute_batch` with bind parameters that are not a list of a hash.  Please switch to passing bind parameters as an array or hash. Support for this behavior will be removed in version 2.0.0.
         eowarn
       end
 
@@ -263,9 +257,7 @@ array or hash. Support for this behavior will be removed in version 2.0.0.
         end
 
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling SQLite3::Database#execute_batch with nil or multiple bind params
-without using an array.  Please switch to passing bind parameters as an array.
-Support for this behavior will be removed in version 2.0.0.
+#{caller[0]} is calling `SQLite3::Database#execute_batch` with nil or multiple bind params without using an array.  Please switch to passing bind parameters as an array. Support for this behavior will be removed in version 2.0.0.
         eowarn
       end
 
@@ -332,9 +324,7 @@ Support for this behavior will be removed in version 2.0.0.
         end
 
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling SQLite3::Database#query with nil or multiple bind params
-without using an array.  Please switch to passing bind parameters as an array.
-Support for this will be removed in version 2.0.0.
+#{caller[0]} is calling `SQLite3::Database#query` with nil or multiple bind params without using an array.  Please switch to passing bind parameters as an array. Support for this will be removed in version 2.0.0.
         eowarn
       end
 

--- a/lib/sqlite3/resultset.rb
+++ b/lib/sqlite3/resultset.rb
@@ -20,18 +20,14 @@ module SQLite3
 
       def types
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling #{self.class}#types.  This method will be removed in
-sqlite3 version 2.0.0, please call the `types` method on the SQLite3::ResultSet
-object that created this object
+#{caller[0]} is calling `#{self.class}#types` which is deprecated and will be removed in sqlite3 version 2.0.0. Please call the `types` method on the SQLite3::ResultSet object that created this object.
         eowarn
         @types
       end
 
       def fields
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling #{self.class}#fields.  This method will be removed in
-sqlite3 version 2.0.0, please call the `columns` method on the SQLite3::ResultSet
-object that created this object
+#{caller[0]} is calling `#{self.class}#fields` which is deprecated and will be removed in sqlite3 version 2.0.0. Please call the `columns` method on the SQLite3::ResultSet object that created this object.
         eowarn
         @fields
       end
@@ -45,18 +41,14 @@ object that created this object
 
       def types
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling #{self.class}#types.  This method will be removed in
-sqlite3 version 2.0.0, please call the `types` method on the SQLite3::ResultSet
-object that created this object
+#{caller[0]} is calling `#{self.class}#types` which is deprecated and will be removed in sqlite3 version 2.0.0. Please call the `types` method on the SQLite3::ResultSet object that created this object.
         eowarn
         @types
       end
 
       def fields
         warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling #{self.class}#fields.  This method will be removed in
-sqlite3 version 2.0.0, please call the `columns` method on the SQLite3::ResultSet
-object that created this object
+#{caller[0]} is calling `#{self.class}#fields` which is deprecated and will be removed in sqlite3 version 2.0.0. Please call the `columns` method on the SQLite3::ResultSet object that created this object.
         eowarn
         @fields
       end

--- a/lib/sqlite3/translator.rb
+++ b/lib/sqlite3/translator.rb
@@ -36,8 +36,7 @@ module SQLite3
     # The block should return the translated value.
     def add_translator( type, &block ) # :yields: type, value
       warn(<<-eowarn) if $VERBOSE
-#{caller[0]} is calling `add_translator`.
-Built in translators are deprecated and will be removed in version 2.0.0
+#{caller[0]} is calling `SQLite3::Translator#add_translator`. Built-in translators are deprecated and will be removed in version 2.0.0.
       eowarn
       @translators[ type_name( type ) ] = block
     end

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -16,7 +16,7 @@ module SQLite3
   def self.const_missing(name)
     return super unless name == :Version
     warn(<<-eowarn) if $VERBOSE
-#{caller[0]}: SQLite::Version will be removed in sqlite3-ruby version 2.0.0
+#{caller[0]}: `SQLite::Version` will be removed in sqlite3-ruby version 2.0.0
     eowarn
     VersionProxy
   end

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -10,8 +10,6 @@ Rake::TestTask.new(:test, &test_config)
 begin
   require "ruby_memcheck"
 
-  RubyMemcheck.config(binary_name: "sqlite3_native")
-
   namespace :test do
     RubyMemcheck::TestTask.new(:valgrind, &test_config)
   end

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -10,10 +10,13 @@ Gem::Specification.new do |s|
   s.name = "sqlite3"
   s.version = defined?(SQLite3::VERSION) ? SQLite3::VERSION : "0.0.0"
 
-  s.summary = "This module allows Ruby programs to interface with the SQLite3 database engine (http://www.sqlite.org)"
-  s.description = "This module allows Ruby programs to interface with the SQLite3\ndatabase engine (http://www.sqlite.org).  You must have the\nSQLite engine installed in order to build this module.\n\nNote that this module is only compatible with SQLite 3.6.16 or newer."
+  s.summary = "Ruby library to interface with the SQLite3 database engine (http://www.sqlite.org)."
+  s.description = <<~TEXT
+    Ruby library to interface with the SQLite3 database engine (http://www.sqlite.org). Precompiled
+    binaries are available for common platforms for recent versions of Ruby.
+  TEXT
 
-  s.authors = ["Jamis Buck", "Luis Lavena", "Aaron Patterson"]
+  s.authors = ["Jamis Buck", "Luis Lavena", "Aaron Patterson", "Mike Dalessio"]
 
   s.licenses = ["BSD-3-Clause"]
 

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -101,15 +101,20 @@ module SQLite3
 
     def test_get_first_row_with_type_translation_and_hash_results
       @db.results_as_hash = true
-      @db.type_translation = true
-      assert_equal({"1"=>1}, @db.get_first_row('SELECT 1'))
+      capture_io do # hush translation deprecation warnings
+        @db.type_translation = true
+        assert_equal({"1"=>1}, @db.get_first_row('SELECT 1'))
+      end
     end
 
     def test_execute_with_type_translation_and_hash
-      @db.results_as_hash = true
-      @db.type_translation = true
       rows = []
-      @db.execute('SELECT 1') { |row| rows << row }
+      @db.results_as_hash = true
+
+      capture_io do # hush translation deprecation warnings
+        @db.type_translation = true
+        @db.execute('SELECT 1') { |row| rows << row }
+      end
 
       assert_equal({"1"=>1}, rows.first)
     end

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -101,8 +101,8 @@ class TC_ResultSet < SQLite3::TestCase
     hash = @result.next
     assert_equal( { "a" => 1, "b" => "foo" },
       hash )
-    assert_equal hash[0], 1
-    assert_equal hash[1], "foo"
+    assert_equal hash[@result.columns[0]], 1
+    assert_equal hash[@result.columns[1]], "foo"
   end
 
   def test_each

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -140,7 +140,9 @@ module SQLite3
       stmt.close
 
       assert_equal ['hello'], row.first
-      assert_equal ['blob'], row.first.types
+      capture_io do # hush deprecation warning
+        assert_equal ['blob'], row.first.types
+      end
     end
 
     def test_bind_64


### PR DESCRIPTION
- address int-to-long compiler warnings on darwin/clang
- improve documented release steps
- drop ruby_memcheck binary name setting
- update gemspec authors, summary, and description
- pin dev dependencies, and turn on dependabot updates
