### PR TITLE
dep: update packaged sqlite to 3.43.1

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,13 +2,13 @@
 :sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3430000.tar.gz
-  # cc321c7b0a70f87aaefe5d0aa89cdd97b432c3d2d448fa623f20988007c49f34  ports/archives/sqlite-autoconf-3430000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3430100.tar.gz
+  # 8c6242fb2abf6a556e849d259134aca9130520b2218f9a7fb1f50eb0528a385a  ports/archives/sqlite-autoconf-3430100.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3430000.tar.gz
-  # 49008dbf3afc04d4edc8ecfc34e4ead196973034293c997adad2f63f01762ae1  ports/archives/sqlite-autoconf-3430000.tar.gz
+  # $ sha256sum ports/archives/sqlite-autoconf-3430100.tar.gz
+  # 46db2f10f306e163e4571b8974d44cd37078aae04295bbf08b253655df3265f4  ports/archives/sqlite-autoconf-3430100.tar.gz
   #
-  :version: "3.43.0"
+  :version: "3.43.1"
   :files:
-    - :url: "https://sqlite.org/2023/sqlite-autoconf-3430000.tar.gz"
-      :sha256: "49008dbf3afc04d4edc8ecfc34e4ead196973034293c997adad2f63f01762ae1"
+    - :url: "https://sqlite.org/2023/sqlite-autoconf-3430100.tar.gz"
+      :sha256: "46db2f10f306e163e4571b8974d44cd37078aae04295bbf08b253655df3265f4"

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -570,5 +570,16 @@ module SQLite3
       assert_raises(TypeError) { db.load_extension(1) }
       assert_raises(TypeError) { db.load_extension(Pathname.new("foo.so")) }
     end
+
+    def test_raw_float_infinity
+      # https://github.com/sparklemotion/sqlite3-ruby/issues/396
+      skip if SQLite3::SQLITE_LOADED_VERSION >= "3.43.0"
+
+      db = SQLite3::Database.new ":memory:"
+      db.execute("create table foo (temperature float)")
+      db.execute("insert into foo values (?)", 37.5)
+      db.execute("insert into foo values (?)", Float::INFINITY)
+      assert_equal Float::INFINITY, db.execute("select avg(temperature) from foo").first.first
+    end
   end
 end


### PR DESCRIPTION

From the changelog at See https://sqlite.org/releaselog/3_43_1.html :

> - Fix a regression in the way that the [sum()](https://sqlite.org/lang_aggfunc.html#sumunc), [avg()](https://sqlite.org/lang_aggfunc.html#avg), and [total()](https://sqlite.org/lang_aggfunc.html#sumunc) aggregate functions handle infinities.
> - Fix a bug in the [json_array_length()](https://sqlite.org/json1.html#jarraylen) function that occurs when the argument comes directly from [json_remove()](https://sqlite.org/json1.html#jrm).
> - Fix the omit-unused-subquery-columns optimization (introduced in in version 3.42.0) so that it works correctly if the subquery is a compound where one arm is DISTINCT and the other is not.
> - Other minor fixes.

Closes #396
