### PR TITLE
dep: update packaged sqlite3 to 3.43.2

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,14 +1,15 @@
 # TODO: stop using symbols here once we no longer support Ruby 2.7 and can rely on symbolize_names
 :sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
+  # a7463a45ed58849200858e514b79f7e5f5d69850047897c5b659a78a0bc75cc1
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3430100.tar.gz
-  # fd32866c281539eae95cd90b5c2c34337d8808822a988211b9b009c1e788e42d  ports/archives/sqlite-autoconf-3430100.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3430200.tar.gz
+  # a7463a45ed58849200858e514b79f7e5f5d69850047897c5b659a78a0bc75cc1  ports/archives/sqlite-autoconf-3430200.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3430100.tar.gz
-  # 39116c94e76630f22d54cd82c3cea308565f1715f716d1b2527f1c9c969ba4d9  ports/archives/sqlite-autoconf-3430100.tar.gz
+  # $ sha256sum ports/archives/sqlite-autoconf-3430200.tar.gz
+  # 6d422b6f62c4de2ca80d61860e3a3fb693554d2f75bb1aaca743ccc4d6f609f0  ports/archives/sqlite-autoconf-3430200.tar.gz
   #
-  :version: "3.43.1"
+  :version: "3.43.2"
   :files:
-    - :url: "https://sqlite.org/2023/sqlite-autoconf-3430100.tar.gz"
-      :sha256: "39116c94e76630f22d54cd82c3cea308565f1715f716d1b2527f1c9c969ba4d9"
+    - :url: "https://sqlite.org/2023/sqlite-autoconf-3430200.tar.gz"
+      :sha256: "6d422b6f62c4de2ca80d61860e3a3fb693554d2f75bb1aaca743ccc4d6f609f0"


### PR DESCRIPTION
From the forum announcement:

> SQLite version 3.43.2 is now available.  Version 3.43.2 is a small patch
to version 3.43.1 and 3.43.0 that fixes some minor inaccuracies and also
addresses some problems in the build scripts.  The changes probably do not
affect your projects, but you are welcomed to upgrade nevertheless.


Details from https://sqlite.org/releaselog/3_43_2.html

> - Fix a couple of obscure UAF errors and an obscure memory leak.
> - Omit the use of the sprintf() function from the standard library in the [CLI](https://sqlite.org/cli.html), as this now generates warnings on some platforms.
> - Avoid conversion of a double into unsigned long long integer, as some platforms do not do such conversions correctly.
