### PR TITLE
dep: remove psych as an explicit dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ gem("minitest", "5.20.0")
 gem("rake-compiler", "1.2.5")
 gem("rake-compiler-dock", "1.3.0")
 gem("rdoc", "6.5.0")
-gem("psych", "5.1.0")
 
 gem("ruby_memcheck", "2.2.0") if Gem::Platform.local.os == "linux"


### PR DESCRIPTION
Psych was only added in #363 because psych 5 wouldn't build on some CI platforms, but that seems to be fixed now.