### PR TITLE
ci: test edge rubies only in upstream.yml

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head", "truffleruby-head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.1", "3.2", "truffleruby-head"]
+        ruby: ["3.1", "3.2", "truffleruby"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -28,9 +28,7 @@ jobs:
         ruby: ["3.2", "3.1", "3.0", "2.7"]
         lib: [system, packaged]
         include:
-          - { os: ubuntu-latest,  ruby: truffleruby-head, lib: packaged }
-          - { os: ubuntu-latest,  ruby: head,             lib: packaged }
-          - { os: ubuntu-latest,  ruby: head,             lib: system   }
+          - { os: ubuntu-latest,  ruby: truffleruby,      lib: packaged }
           - { os: windows-latest, ruby: ucrt,             lib: system   }
           - { os: windows-latest, ruby: mswin,            lib: system   }
 

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -6,6 +6,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
+    paths:
+      - .github/workflows/upstream.yml # this file
 
 jobs:
   sqlite-head:
@@ -20,4 +26,36 @@ jobs:
           ruby-version: "3.1"
           bundler-cache: true
       - run: bundle exec rake compile -- --with-sqlite-source-dir=${GITHUB_WORKSPACE}/sqlite
+      - run: bundle exec rake test
+
+  ruby-head:
+    name: ${{matrix.ruby}}-${{matrix.lib}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,  ruby: truffleruby-head, lib: packaged }
+          - { os: ubuntu-latest,  ruby: head,             lib: packaged }
+          - { os: ubuntu-latest,  ruby: head,             lib: system   }
+
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+          apt-get: libsqlite3-dev
+      - if: matrix.lib == 'packaged'
+        uses: actions/cache@v3
+        with:
+          path: ports
+          key: ports-${{matrix.os}}-${{hashFiles('ext/sqlite3/extconf.rb','dependencies.yml')}}
+
+      - run: bundle exec rake compile -- --disable-system-libraries
+        if: matrix.lib == 'packaged'
+
+      - run: bundle exec rake compile -- --enable-system-libraries
+        if: matrix.lib == 'system'
+
       - run: bundle exec rake test


### PR DESCRIPTION
The issue described at https://github.com/oracle/truffleruby/issues/3328 highlighted that we're testing edge rubies in the primary CI pipeline, causing noisy false negative signals.

Let's adopt the same practice as Nokogiri, and test edge rubies in an "upstream" pipeline, and test only stable rubies in the primary CI pipelines.
