### PR TITLE
dep: drop support for old rubies

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -288,7 +288,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "head"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -306,7 +306,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -324,7 +324,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3-rc"]
+        ruby: ["3.0", "3.1", "3.2", "3.3-rc"]
     runs-on: ubuntu-latest
     container:
       image: ruby:${{matrix.ruby}}-alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # sqlite3-ruby Changelog
 
+## next / unreleased
+
+### Ruby
+
+This release introduces native gem support for Ruby 3.3.
+
+This release ends native gem support for Ruby 2.7, for which [upstream support ended 2022-04-12](https://www.ruby-lang.org/en/downloads/branches/). Ruby 2.7 is still generally supported, but will not be shipped in the native gems.
+
+This release ends support for Ruby 1.9.3, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, and 2.6.
+
+
 ## 1.6.9 / 2023-11-26
 
 ### Dependencies

--- a/bin/test-gem-file-contents
+++ b/bin/test-gem-file-contents
@@ -66,9 +66,9 @@ Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 puts "Testing '#{gemfile}' (#{gemspec.platform})"
 describe File.basename(gemfile) do
   let(:all_supported_ruby_versions) {
-    ["1.9.2", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+    ["2.7", "3.0", "3.1", "3.2", "3.3"]
   }
-  let(:native_supported_ruby_versions) { ["2.7", "3.0", "3.1", "3.2", "3.3"] }
+  let(:native_supported_ruby_versions) { ["3.0", "3.1", "3.2", "3.3"] }
   let(:ucrt_supported_ruby_versions) { ["3.1", "3.2", "3.3"] }
   let(:platform_supported_ruby_versions) do
     if gemspec.platform.to_s == "x64-mingw-ucrt"

--- a/rakelib/native.rake
+++ b/rakelib/native.rake
@@ -6,7 +6,7 @@ require "rake/extensiontask"
 require "rake_compiler_dock"
 require "yaml"
 
-cross_rubies = ["3.3.0", "3.2.0", "3.1.0", "3.0.0", "2.7.0"]
+cross_rubies = ["3.3.0", "3.2.0", "3.1.0", "3.0.0"]
 cross_platforms = [
   "aarch64-linux",
   "arm-linux",

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ["BSD-3-Clause"]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   s.homepage = "https://github.com/sparklemotion/sqlite3-ruby"
   s.metadata = {


### PR DESCRIPTION
- drop support completely for Ruby `1.9.2 .. 2.6` (inclusive)
- drop native gem support for 2.7 (but keep general support for 2.7)

I'd really like feedback on dropping so many old versions. The honest truth is that we haven't tested anything older than 2.7 for the last year, anyway.
