### PR TITLE
ci: pin alpine to 3.18

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -324,10 +324,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3-rc"]
+        include:
+          - { ruby: "3.0", flavor: "alpine" }
+          - { ruby: "3.1", flavor: "alpine3.18" }
+          - { ruby: "3.2", flavor: "alpine3.18" }
+          - { ruby: "3.3-rc", flavor: "alpine3.18" }
     runs-on: ubuntu-latest
     container:
-      image: ruby:${{matrix.ruby}}-alpine
+      image: ruby:${{matrix.ruby}}-${{matrix.flavor}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
because 3.19 fails due to #434. While I work on better musl support, this makes CI a bit more meaningful.