### PR TITLE
Add a busy_handler_timeout setter

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -691,7 +691,7 @@ module SQLite3
       @readonly
     end
 
-    def lock_wait_timeout=( milliseconds )
+    def busy_handler_timeout=( milliseconds )
       timeout_seconds = milliseconds.fdiv(1000)
       retry_interval = 0.001 # 1 millisecond
 

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -697,13 +697,12 @@ module SQLite3
     # while SQLite sleeps and retries.
     def busy_handler_timeout=( milliseconds )
       timeout_seconds = milliseconds.fdiv(1000)
-      retry_interval = 0.001 # 1 millisecond
       timeout_deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
       busy_handler do |count|
         next false if Process.clock_gettime(Process::CLOCK_MONOTONIC) > timeout_deadline
 
-        sleep(retry_interval)
+        sleep(0.001)
       end
     end
 

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -691,6 +691,19 @@ module SQLite3
       @readonly
     end
 
+    def lock_wait_timeout=( milliseconds )
+      timeout_seconds = milliseconds.fdiv(1000)
+      retry_interval = 0.001 # 1 millisecond
+
+      busy_handler do |count|
+        @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) if count == 0
+
+        next sleep(retry_interval) unless (count % 100) == 0
+
+        (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time) <= timeout_seconds
+      end
+    end
+
     # A helper class for dealing with custom functions (see #create_function,
     # #create_aggregate, and #create_aggregate_handler). It encapsulates the
     # opaque function object that represents the current invocation. It also

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -129,9 +129,6 @@ class TC_Integration_Pending < SQLite3::TestCase
       begin
         db2 = SQLite3::Database.open( "test.db" )
         db2.busy_timeout 1000
-        # db2.busy_handler do |count|
-        #   sleep 0.001
-        # end
         db2.transaction( :exclusive ) do
           sleep 0.01
         end
@@ -144,7 +141,7 @@ class TC_Integration_Pending < SQLite3::TestCase
       [t1, t2].each(&:join)
     end
 
-    assert time.real >= 1
+    assert_operator time.real, :>=, 1
   end
 
   def test_busy_handler_timeout_releases_gvl
@@ -175,6 +172,6 @@ class TC_Integration_Pending < SQLite3::TestCase
       [t1, t2].each(&:join)
     end
 
-    assert time.real < 1
+    assert_operator time.real, :<, 1
   end
 end

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -113,8 +113,8 @@ class TC_Integration_Pending < SQLite3::TestCase
     assert time.real*1000 >= 1000
   end
 
-  def test_lock_wait_timeout
-    @db.lock_wait_timeout = 1000
+  def test_busy_handler_timeout
+    @db.busy_handler_timeout = 1000
     busy = Mutex.new
     busy.lock
 

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -128,6 +128,7 @@ class TC_Integration_Pending < SQLite3::TestCase
     db2.close
 
     assert_operator time.real, :>=, 2
+    assert_operator time.real, :<, 3
   end
 
   def test_busy_handler_timeout_releases_gvl
@@ -145,5 +146,6 @@ class TC_Integration_Pending < SQLite3::TestCase
     db2.close
 
     assert_operator time.real, :>=, 1
+    assert_operator time.real, :<, 2
   end
 end

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -116,12 +116,16 @@ class TC_Integration_Pending < SQLite3::TestCase
   def test_busy_timeout_blocks_gvl
     threads = [1, 2].map do
       Thread.new do
-        db = SQLite3::Database.new("test.db")
-        db.busy_timeout = 3000
-        db.transaction(:immediate) do
-          db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-          sleep 1
-          db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+        begin
+          db = SQLite3::Database.new("test.db")
+          db.busy_timeout = 3000
+          db.transaction(:immediate) do
+            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+            sleep 1
+            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+          end
+        ensure
+          db.close if db
         end
       end
     end
@@ -134,12 +138,16 @@ class TC_Integration_Pending < SQLite3::TestCase
   def test_busy_handler_timeout_releases_gvl
     threads = [1, 2].map do
       Thread.new do
-        db = SQLite3::Database.new("test.db")
-        db.busy_handler_timeout = 3000
-        db.transaction(:immediate) do
-          db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-          sleep 1
-          db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+        begin
+          db = SQLite3::Database.new("test.db")
+          db.busy_handler_timeout = 3000
+          db.transaction(:immediate) do
+            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+            sleep 1
+            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
+          end
+        ensure
+          db.close if db
         end
       end
     end


### PR DESCRIPTION
One of the largest pain-points when using SQLite in a Rails app is the limited concurrency support. While SQLite does support only one writer, from a Rails app's point-of-view this does not mean that that app simply cannot run in, for example, Puma clustered mode. As I have [detailed](https://fractaledmind.github.io/2023/12/11/sqlite-on-rails-improving-concurrency/), the primary issues are that the GVL isn't released while the SQLite `busy_timeout` C function is running and transactions are run in `DEFERRED` mode. 

We can solve the first of these by providing a Ruby `busy_handler` callback that will release the GVL between retries. This allows multiple threads to naturally coordinate and "queue up" to acquire SQLite's single write lock.

I initially proposed providing this in the Rails codebase (see: https://github.com/rails/rails/pull/50370); however, it was suggested that this functionality more naturally belongs in this codebase. So, I would love to start brainstorming the interface for this. Once built and released, we can then update Rails to use this instead of the `busy_timeout`. 

Jean Boussier suggested `lock_wait_timeout` as a name. I'm opening this PR to get the ball rolling. I'm open to naming suggestions as well as test suggestions.