### PR TITLE
ci: update pipelines to test with ruby 3.3.0 final

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -30,7 +30,7 @@ jobs:
           key: ports-archives-tarball-${{hashFiles('ext/sqlite3/extconf.rb','dependencies.yml')}}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec ruby ./ext/sqlite3/extconf.rb --download-dependencies
       - id: rcd_image_version
@@ -47,7 +47,7 @@ jobs:
           key: ports-archives-tarball-${{hashFiles('ext/sqlite3/extconf.rb','dependencies.yml')}}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: true
       - run: ./bin/test-gem-build gems ruby
       - uses: actions/upload-artifact@v3
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.1", "3.2", "head", "truffleruby"]
+        ruby: ["3.1", "3.2", "3.3", "truffleruby"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.1", "3.2", "head"]
+        ruby: ["3.1", "3.2", "3.3"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -226,7 +226,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "head"]
+        ruby: ["3.1", "3.2", "3.3"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -288,7 +288,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -306,7 +306,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -328,7 +328,7 @@ jobs:
           - { ruby: "3.0", flavor: "alpine" }
           - { ruby: "3.1", flavor: "alpine3.18" }
           - { ruby: "3.2", flavor: "alpine3.18" }
-          - { ruby: "3.3-rc", flavor: "alpine3.18" }
+          - { ruby: "3.3", flavor: "alpine3.18" }
     runs-on: ubuntu-latest
     container:
       image: ruby:${{matrix.ruby}}-${{matrix.flavor}}

--- a/.github/workflows/sqlite3-ruby.yml
+++ b/.github/workflows/sqlite3-ruby.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["head", "3.2", "3.1", "3.0", "2.7"]
+        ruby: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         lib: [system, packaged]
         include:
           - { os: ubuntu-latest,  ruby: truffleruby,      lib: packaged }
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.2", "2.7"] # oldest and newest
+        ruby: ["3.3", "2.7"] # oldest and newest
         include:
           - { os: windows-latest, ruby: mingw }
           - { os: windows-latest, ruby: mswin }
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           apt-get: libsqlite3-dev valgrind
       - run: bundle install

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,7 +23,7 @@ jobs:
           git -C sqlite log -n1
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rake compile -- --with-sqlite-source-dir=${GITHUB_WORKSPACE}/sqlite
       - run: bundle exec rake test


### PR DESCRIPTION
Note that this won't go green until there are official docker images for ruby:3.3 and there's a windows build available from rubyinstaller2 for setup-ruby to use.