### PR TITLE
busy_handler_timeout pt2

### DIFF
--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -114,7 +114,8 @@ class TC_Integration_Pending < SQLite3::TestCase
     busy.unlock
     t.join
 
-    assert 2 == work.size - work.find_index(">")
+    p ['busy_timeout', work]
+    assert 2 >= work.size - work.find_index(">")
   end
 
   def test_busy_handler_timeout_releases_gvl
@@ -160,6 +161,7 @@ class TC_Integration_Pending < SQLite3::TestCase
     busy.unlock
     t.join
 
+    p ['busy_handler_timeout', work]
     assert 2 < work.size - work.find_index(">")
   end
 end

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -127,6 +127,7 @@ class TC_Integration_Pending < SQLite3::TestCase
         work << '.'
       end
     end
+    sleep 1
 
     @db.busy_handler do |count|
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -80,44 +80,6 @@ class TC_Integration_Pending < SQLite3::TestCase
     assert time.real*1000 >= 1000
   end
 
-  def test_busy_timeout_holds_gvl
-    work = []
-    Thread.new do
-      while true
-        sleep 0.1
-        work << '.'
-      end
-    end
-    sleep 1
-
-    @db.busy_timeout 1000
-    busy = Mutex.new
-    busy.lock
-
-    t = Thread.new do
-      begin
-        db2 = SQLite3::Database.open( "test.db" )
-        db2.transaction( :exclusive ) do
-          busy.lock
-        end
-      ensure
-        db2.close if db2
-      end
-    end
-    sleep 1
-
-    assert_raises( SQLite3::BusyException ) do
-      work << '>'
-      @db.execute "insert into foo (b) values ( 'from 2' )"
-    end
-
-    busy.unlock
-    t.join
-
-    p ['busy_timeout', work]
-    assert 2 >= work.size - work.find_index(">")
-  end
-
   def test_busy_handler_timeout_releases_gvl
     work = []
 
@@ -155,14 +117,13 @@ class TC_Integration_Pending < SQLite3::TestCase
     sleep 1
 
     assert_raises( SQLite3::BusyException ) do
-      work << '>'
+      work << '|'
       @db.execute "insert into foo (b) values ( 'from 2' )"
     end
 
     busy.unlock
     t.join
 
-    p ['busy_handler_timeout', work]
-    assert 2 < work.size - work.find_index(">")
+    assert work.size - work.find_index('|') > 3
   end
 end

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -91,16 +91,7 @@ class TC_Integration_Pending < SQLite3::TestCase
     end
     sleep 1
 
-    @db.busy_handler do |count|
-      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      if count.zero?
-        @timeout_deadline = now + 1
-      elsif now > @timeout_deadline
-        next false
-      else
-        sleep(0.001)
-      end
-    end
+    @db.busy_handler_timeout = 1000
     busy = Mutex.new
     busy.lock
 


### PR DESCRIPTION
Since https://github.com/sparklemotion/sqlite3-ruby/pull/443 required a revert (https://github.com/sparklemotion/sqlite3-ruby/pull/457) because the test for `busy_timeout` holding the GVL such that other working threads could not progress was flaky (particularly on `windows-latest, packaged` CI builds), this PR re-introduces the `busy_handler_timeout` but with only one resilient test that the `busy_handler_timeout` definitely does allow other working threads to progress. The negative test of `busy_timeout` is unnecessary in addition to being flaky.

