### PR TITLE
Revert pull request #443 from fractaledmind/lock-wait-timeout

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -131,7 +131,6 @@ module SQLite3
       @type_translator  = make_type_translator @type_translation
       @readonly         = mode & Constants::Open::READONLY != 0
       @default_transaction_mode = options[:default_transaction_mode] || :deferred
-      @timeout_deadline = nil
 
       if block_given?
         begin
@@ -697,25 +696,6 @@ module SQLite3
     # A helper to check before performing any operation
     def readonly?
       @readonly
-    end
-
-    # Sets a #busy_handler that releases the GVL between retries,
-    # but only retries up to the indicated number of +milliseconds+.
-    # This is an alternative to #busy_timeout, which holds the GVL
-    # while SQLite sleeps and retries.
-    def busy_handler_timeout=( milliseconds )
-      timeout_seconds = milliseconds.fdiv(1000)
-
-      busy_handler do |count|
-        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        if count.zero?
-          @timeout_deadline = now + timeout_seconds
-        elsif now > @timeout_deadline
-          next false
-        else
-          sleep(0.001)
-        end
-      end
     end
 
     # A helper class for dealing with custom functions (see #create_function,

--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -79,48 +79,4 @@ class TC_Integration_Pending < SQLite3::TestCase
 
     assert time.real*1000 >= 1000
   end
-
-  def test_busy_timeout_blocks_gvl
-    threads = [1, 2].map do
-      Thread.new do
-        begin
-          db = SQLite3::Database.new("test.db")
-          db.busy_timeout = 3000
-          db.transaction(:immediate) do
-            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-            sleep 1
-            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-          end
-        ensure
-          db.close if db
-        end
-      end
-    end
-
-    assert_raise( SQLite3::BusyException ) do
-      threads.each(&:join)
-    end
-  end
-
-  def test_busy_handler_timeout_releases_gvl
-    threads = [1, 2].map do
-      Thread.new do
-        begin
-          db = SQLite3::Database.new("test.db")
-          db.busy_handler_timeout = 3000
-          db.transaction(:immediate) do
-            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-            sleep 1
-            db.execute "insert into foo ( b ) values ( ? )", rand(1000).to_s
-          end
-        ensure
-          db.close if db
-        end
-      end
-    end
-
-    assert_nothing_raised do
-      threads.each(&:join)
-    end
-  end
 end


### PR DESCRIPTION
After chatting with @fractaledmind and @tenderlove I've reverting this until we understand the CI flakiness and get get a repeatable green.

This PR is the outcome of running:

    git revert f80c5ff0..0c93d308