### PR TITLE
Implement progress handler interface

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -124,6 +124,7 @@ module SQLite3
       @authorizer       = nil
       @encoding         = nil
       @busy_handler     = nil
+      @progress_handler = nil
       @collations       = {}
       @functions        = {}
       @results_as_hash  = options[:results_as_hash]


### PR DESCRIPTION
This adds support for the [`progress_handler`](https://www.sqlite.org/c3ref/progress_handler.html) SQLite interface. Such a callback is useful as it allows for statement timeouts to be defined. For example, we could define a `statement_timeout=` method on the database instance like so:
```ruby
def statement_timeout=( milliseconds )
  timeout_seconds = milliseconds.fdiv(1000)

  progress_handler do
    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    if @statement_timeout_deadline.nil?
      @statement_timeout_deadline = now + timeout_seconds
    elsif now > @statement_timeout_deadline
      next false
    else
      true
    end
  end
end
```

Note: I don't know C, so this PR was written using pattern matching (primarily on the `rb_sqlite3_busy_handler` and `busy_handler` methods), some Googling (for how to get the correct format for `rb_scan_args`), and ChatGPT (to explain what all of this C code was doing). 

