### PR TITLE
Synchronize threads to remove "sleep 1".

### DIFF
--- a/test/test_integration_pending.rb
+++ b/test/test_integration_pending.rb
@@ -4,6 +4,39 @@ require 'thread'
 require 'benchmark'
 
 class TC_Integration_Pending < SQLite3::TestCase
+  class ThreadSynchronizer
+    def initialize
+      @main_to_thread = Queue.new
+      @thread_to_main = Queue.new
+    end
+
+    def send_to_thread state
+      @main_to_thread.push state
+    end
+
+    def send_to_main state
+      @thread_to_main.push state
+    end
+
+    def wait_for_thread expected_state
+      state = @thread_to_main.pop
+      raise "Invalid state #{state}. #{expected_state} is expected" if state != expected_state
+    end
+
+    def wait_for_main expected_state
+      state = @main_to_thread.pop
+      raise "Invalid state #{state}. #{expected_state} is expected" if state != expected_state
+    end
+
+    def close_thread
+      @thread_to_main.close
+    end
+
+    def close_main
+      @main_to_thread.close
+    end
+  end
+
   def setup
     @db = SQLite3::Database.new("test.db")
     @db.transaction do
@@ -19,22 +52,59 @@ class TC_Integration_Pending < SQLite3::TestCase
     File.delete( "test.db" )
   end
 
-  def test_busy_handler_impatient
-    busy = Mutex.new
-    busy.lock
+  def test_busy_handler_outwait
+    synchronizer = ThreadSynchronizer.new
     handler_call_count = 0
 
-    t = Thread.new do
+    t = Thread.new( synchronizer ) do |sync|
       begin
         db2 = SQLite3::Database.open( "test.db" )
         db2.transaction( :exclusive ) do
-          busy.lock
+          sync.send_to_main :ready_0
+          sync.wait_for_main :busy_handler_called_1
+        end
+        sync.send_to_main :end_of_transaction_2
+      ensure
+        db2.close if db2
+        sync.close_thread
+      end
+    end
+
+    @db.busy_handler do |count|
+      handler_call_count += 1
+      synchronizer.send_to_thread :busy_handler_called_1
+      synchronizer.wait_for_thread :end_of_transaction_2
+      true
+    end
+
+    synchronizer.wait_for_thread :ready_0
+    assert_nothing_raised do
+      @db.execute "insert into foo (b) values ( 'from 2' )"
+    end
+
+    synchronizer.close_main
+    t.join
+
+    assert_equal 1, handler_call_count
+  end
+
+  def test_busy_handler_impatient
+    synchronizer = ThreadSynchronizer.new
+    handler_call_count = 0
+
+    t = Thread.new( synchronizer ) do |sync|
+      begin
+        db2 = SQLite3::Database.open( "test.db" )
+        db2.transaction( :exclusive ) do
+          sync.send_to_main :ready_0
+          sync.wait_for_main :end_1
         end
       ensure
         db2.close if db2
+        sync.close_thread
       end
     end
-    sleep 1
+    synchronizer.wait_for_thread :ready_0
 
     @db.busy_handler do
       handler_call_count += 1
@@ -45,7 +115,8 @@ class TC_Integration_Pending < SQLite3::TestCase
       @db.execute "insert into foo (b) values ( 'from 2' )"
     end
 
-    busy.unlock
+    synchronizer.send_to_thread :end_1
+    synchronizer.close_main
     t.join
 
     assert_equal 1, handler_call_count
@@ -53,28 +124,30 @@ class TC_Integration_Pending < SQLite3::TestCase
 
   def test_busy_timeout
     @db.busy_timeout 1000
-    busy = Mutex.new
-    busy.lock
+    synchronizer = ThreadSynchronizer.new
 
-    t = Thread.new do
+    t = Thread.new( synchronizer ) do |sync|
       begin
         db2 = SQLite3::Database.open( "test.db" )
         db2.transaction( :exclusive ) do
-          busy.lock
+          sync.send_to_main :ready_0
+          sync.wait_for_main :end_1
         end
       ensure
         db2.close if db2
+        sync.close_thread
       end
     end
 
-    sleep 1
+    synchronizer.wait_for_thread :ready_0
     time = Benchmark.measure do
       assert_raise( SQLite3::BusyException ) do
         @db.execute "insert into foo (b) values ( 'from 2' )"
       end
     end
 
-    busy.unlock
+    synchronizer.send_to_thread :end_1
+    synchronizer.close_main
     t.join
 
     assert time.real*1000 >= 1000


### PR DESCRIPTION
I revived `test_busy_handler_outwait` because I think that this test covers a good use case regarding `busy_handler`.

Ruby 1.9 and later does not allow a thread to unlock a `Mutex` locked by another thread, so I used `Queue` to synchronize the main thread and another thread.
I also refined other test methods to remove `sleep 1`, which was used to synchronize threads.

I hope this pull request improves this project, but please feel free to ignore it if it is not so useful.

Regards,
Murase
