### PR TITLE
Implement sqlite3_stmt_status interface

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -415,7 +415,8 @@ bind_parameter_count(VALUE self)
  *
  * Return the number of times that SQLite has stepped forward in a table as part of a full table scan
  */
-static VALUE fullscan_steps(VALUE self)
+static VALUE
+fullscan_steps(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -428,7 +429,8 @@ static VALUE fullscan_steps(VALUE self)
  *
  * Return the number of sort operations that have occurred
  */
-static VALUE sorts(VALUE self)
+static VALUE
+sorts(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -441,7 +443,8 @@ static VALUE sorts(VALUE self)
  *
  * Return the number of rows inserted into transient indices that were created automatically in order to help joins run faster
  */
-static VALUE autoindexes(VALUE self)
+static VALUE
+autoindexes(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -454,7 +457,8 @@ static VALUE autoindexes(VALUE self)
  *
  * Return the number of virtual machine operations executed by the prepared statement
  */
-static VALUE vm_steps(VALUE self)
+static VALUE
+vm_steps(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -463,11 +467,13 @@ static VALUE vm_steps(VALUE self)
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_VM_STEP, 0));
 }
 
+#ifdef SQLITE_STMTSTATUS_REPREPARE
 /* call-seq: stmt.reprepares
  *
  * Return the number of times that the prepare statement has been automatically regenerated due to schema changes or changes to bound parameters that might affect the query plan.
  */
-static VALUE reprepares(VALUE self)
+static VALUE
+reprepares(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -475,12 +481,15 @@ static VALUE reprepares(VALUE self)
 
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_REPREPARE, 0));
 }
+#endif
 
+#ifdef SQLITE_STMTSTATUS_RUN
 /* call-seq: stmt.runs
  *
  * Return the number of times that the prepared statement has been run
  */
-static VALUE runs(VALUE self)
+static VALUE
+runs(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -488,12 +497,15 @@ static VALUE runs(VALUE self)
 
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_RUN, 0));
 }
+#endif
 
+#ifdef SQLITE_STMTSTATUS_FILTER_MISS
 /* call-seq: stmt.filter_misses
  *
  * Return the number of times that the Bloom filter returned a find, and thus the join step had to be processed as normal.
  */
-static VALUE filter_misses(VALUE self)
+static VALUE
+filter_misses(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -501,12 +513,15 @@ static VALUE filter_misses(VALUE self)
 
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_FILTER_MISS, 0));
 }
+#endif
 
+#ifdef SQLITE_STMTSTATUS_FILTER_HIT
 /* call-seq: stmt.filter_hits
  *
  * Return the number of times that a join step was bypassed because a Bloom filter returned not-found
  */
-static VALUE filter_hits(VALUE self)
+static VALUE
+filter_hits(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -514,12 +529,15 @@ static VALUE filter_hits(VALUE self)
 
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_FILTER_HIT, 0));
 }
+#endif
 
+#ifdef SQLITE_STMTSTATUS_MEMUSED
 /* call-seq: stmt.memory_used
  *
  * Return the approximate number of bytes of heap memory used to store the prepared statement
  */
-static VALUE memused(VALUE self)
+static VALUE
+memused(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -527,6 +545,7 @@ static VALUE memused(VALUE self)
 
     return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_MEMUSED, 0));
 }
+#endif
 
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
 
@@ -568,14 +587,29 @@ init_sqlite3_statement(void)
     rb_define_method(cSqlite3Statement, "sorts", sorts, 0);
     rb_define_method(cSqlite3Statement, "autoindexes", autoindexes, 0);
     rb_define_method(cSqlite3Statement, "vm_steps", vm_steps, 0);
-    rb_define_method(cSqlite3Statement, "reprepares", reprepares, 0);
-    rb_define_method(cSqlite3Statement, "runs", runs, 0);
-    rb_define_method(cSqlite3Statement, "filter_misses", filter_misses, 0);
-    rb_define_method(cSqlite3Statement, "filter_hits", filter_hits, 0);
-    rb_define_method(cSqlite3Statement, "memused", memused, 0);
     rb_define_private_method(cSqlite3Statement, "prepare", prepare, 2);
 
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
     rb_define_method(cSqlite3Statement, "database_name", database_name, 1);
+#endif
+
+#ifdef SQLITE_STMTSTATUS_REPREPARE
+    rb_define_method(cSqlite3Statement, "reprepares", reprepares, 0);
+#endif
+
+#ifdef SQLITE_STMTSTATUS_RUN
+    rb_define_method(cSqlite3Statement, "runs", runs, 0);
+#endif
+
+#ifdef SQLITE_STMTSTATUS_FILTER_MISS
+    rb_define_method(cSqlite3Statement, "filter_misses", filter_misses, 0);
+#endif
+
+#ifdef SQLITE_STMTSTATUS_FILTER_HIT
+    rb_define_method(cSqlite3Statement, "filter_hits", filter_hits, 0);
+#endif
+
+#ifdef SQLITE_STMTSTATUS_MEMUSED
+    rb_define_method(cSqlite3Statement, "memused", memused, 0);
 #endif
 }

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -594,6 +594,9 @@ init_sqlite3_statement(void)
     rb_define_method(cSqlite3Statement, "column_name", column_name, 1);
     rb_define_method(cSqlite3Statement, "column_decltype", column_decltype, 1);
     rb_define_method(cSqlite3Statement, "bind_parameter_count", bind_parameter_count, 0);
+#ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
+    rb_define_method(cSqlite3Statement, "database_name", database_name, 1);
+#endif
 #ifdef SQLITE_STMTSTATUS_MEMUSED
     rb_define_method(cSqlite3Statement, "memused", memused, 0);
 #endif

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -435,11 +435,11 @@ static VALUE sorts(VALUE self)
   return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_SORT, 0));
 }
 
-/* call-seq: stmt.auto_indexes
+/* call-seq: stmt.autoindexes
  *
  * Return the number of rows inserted into transient indices that were created automatically in order to help joins run faster
  */
-static VALUE auto_indexes(VALUE self)
+static VALUE autoindexes(VALUE self)
 {
   sqlite3StmtRubyPtr ctx;
   TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -448,7 +448,7 @@ static VALUE auto_indexes(VALUE self)
   return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_AUTOINDEX, 0));
 }
 
-/* call-seq: stmt.auto_indexes
+/* call-seq: stmt.vm_steps
  *
  * Return the number of virtual machine operations executed by the prepared statement
  */
@@ -461,11 +461,11 @@ static VALUE vm_steps(VALUE self)
   return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_VM_STEP, 0));
 }
 
-/* call-seq: stmt.auto_indexes
+/* call-seq: stmt.reprepares
  *
  * Return the number of times that the prepare statement has been automatically regenerated due to schema changes or changes to bound parameters that might affect the query plan.
  */
-static VALUE re_prepares(VALUE self)
+static VALUE reprepares(VALUE self)
 {
   sqlite3StmtRubyPtr ctx;
   TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -517,7 +517,7 @@ static VALUE filter_hits(VALUE self)
  *
  * Return the approximate number of bytes of heap memory used to store the prepared statement
  */
-static VALUE memory_used(VALUE self)
+static VALUE memused(VALUE self)
 {
   sqlite3StmtRubyPtr ctx;
   TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
@@ -563,13 +563,13 @@ void init_sqlite3_statement(void)
   rb_define_method(cSqlite3Statement, "bind_parameter_count", bind_parameter_count, 0);
   rb_define_method(cSqlite3Statement, "fullscan_steps", fullscan_steps, 0);
   rb_define_method(cSqlite3Statement, "sorts", sorts, 0);
-  rb_define_method(cSqlite3Statement, "auto_indexes", auto_indexes, 0);
+  rb_define_method(cSqlite3Statement, "autoindexes", autoindexes, 0);
   rb_define_method(cSqlite3Statement, "vm_steps", vm_steps, 0);
-  rb_define_method(cSqlite3Statement, "re_prepares", re_prepares, 0);
+  rb_define_method(cSqlite3Statement, "reprepares", reprepares, 0);
   rb_define_method(cSqlite3Statement, "runs", runs, 0);
   rb_define_method(cSqlite3Statement, "filter_misses", filter_misses, 0);
   rb_define_method(cSqlite3Statement, "filter_hits", filter_hits, 0);
-  rb_define_method(cSqlite3Statement, "memory_used", memory_used, 0);
+  rb_define_method(cSqlite3Statement, "memused", memused, 0);
 
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
   rb_define_method(cSqlite3Statement, "database_name", database_name, 1);

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -409,6 +409,123 @@ static VALUE bind_parameter_count(VALUE self)
   return INT2NUM(sqlite3_bind_parameter_count(ctx->st));
 }
 
+/* call-seq: stmt.fullscan_steps
+ *
+ * Return the number of times that SQLite has stepped forward in a table as part of a full table scan
+ */
+static VALUE fullscan_steps(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_FULLSCAN_STEP, 0));
+}
+
+/* call-seq: stmt.sorts
+ *
+ * Return the number of sort operations that have occurred
+ */
+static VALUE sorts(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_SORT, 0));
+}
+
+/* call-seq: stmt.auto_indexes
+ *
+ * Return the number of rows inserted into transient indices that were created automatically in order to help joins run faster
+ */
+static VALUE auto_indexes(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_AUTOINDEX, 0));
+}
+
+/* call-seq: stmt.auto_indexes
+ *
+ * Return the number of virtual machine operations executed by the prepared statement
+ */
+static VALUE vm_steps(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_VM_STEP, 0));
+}
+
+/* call-seq: stmt.auto_indexes
+ *
+ * Return the number of times that the prepare statement has been automatically regenerated due to schema changes or changes to bound parameters that might affect the query plan.
+ */
+static VALUE re_prepares(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_REPREPARE, 0));
+}
+
+/* call-seq: stmt.runs
+ *
+ * Return the number of times that the prepared statement has been run
+ */
+static VALUE runs(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_RUN, 0));
+}
+
+/* call-seq: stmt.filter_misses
+ *
+ * Return the number of times that the Bloom filter returned a find, and thus the join step had to be processed as normal.
+ */
+static VALUE filter_misses(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_FILTER_MISS, 0));
+}
+
+/* call-seq: stmt.filter_hits
+ *
+ * Return the number of times that a join step was bypassed because a Bloom filter returned not-found
+ */
+static VALUE filter_hits(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_FILTER_HIT, 0));
+}
+
+/* call-seq: stmt.memory_used
+ *
+ * Return the approximate number of bytes of heap memory used to store the prepared statement
+ */
+static VALUE memory_used(VALUE self)
+{
+  sqlite3StmtRubyPtr ctx;
+  TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
+  REQUIRE_OPEN_STMT(ctx);
+
+  return INT2NUM(sqlite3_stmt_status(ctx->st, SQLITE_STMTSTATUS_MEMUSED, 0));
+}
+
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
 
 /* call-seq: stmt.database_name(column_index)
@@ -444,6 +561,15 @@ void init_sqlite3_statement(void)
   rb_define_method(cSqlite3Statement, "column_name", column_name, 1);
   rb_define_method(cSqlite3Statement, "column_decltype", column_decltype, 1);
   rb_define_method(cSqlite3Statement, "bind_parameter_count", bind_parameter_count, 0);
+  rb_define_method(cSqlite3Statement, "fullscan_steps", fullscan_steps, 0);
+  rb_define_method(cSqlite3Statement, "sorts", sorts, 0);
+  rb_define_method(cSqlite3Statement, "auto_indexes", auto_indexes, 0);
+  rb_define_method(cSqlite3Statement, "vm_steps", vm_steps, 0);
+  rb_define_method(cSqlite3Statement, "re_prepares", re_prepares, 0);
+  rb_define_method(cSqlite3Statement, "runs", runs, 0);
+  rb_define_method(cSqlite3Statement, "filter_misses", filter_misses, 0);
+  rb_define_method(cSqlite3Statement, "filter_hits", filter_hits, 0);
+  rb_define_method(cSqlite3Statement, "memory_used", memory_used, 0);
 
 #ifdef HAVE_SQLITE3_COLUMN_DATABASE_NAME
   rb_define_method(cSqlite3Statement, "database_name", database_name, 1);

--- a/lib/sqlite3/statement.rb
+++ b/lib/sqlite3/statement.rb
@@ -145,6 +145,29 @@ module SQLite3
       end
     end
 
+    # Returns a Hash containing information about the statement.
+    # The contents of the hash are implementation specific and may change in
+    # the future without notice. The hash includes information about internal
+    # statistics about the statement such as:
+    #   - +fullscan_steps+: the number of times that SQLite has stepped forward
+    # in a table as part of a full table scan
+    #   - +sorts+: the number of sort operations that have occurred
+    #   - +autoindexes+: the number of rows inserted into transient indices
+    # that were created automatically in order to help joins run faster
+    #   - +vm_steps+: the number of virtual machine operations executed by the
+    # prepared statement
+    #   - +reprepares+: the number of times that the prepare statement has been
+    # automatically regenerated due to schema changes or changes to bound
+    # parameters that might affect the query plan
+    #   - +runs+: the number of times that the prepared statement has been run
+    #   - +filter_misses+: the number of times that the Bloom filter returned
+    # a find, and thus the join step had to be processed as normal
+    #   - +filter_hits+: the number of times that a join step was bypassed
+    # because a Bloom filter returned not-found
+    def stat hash_or_key = nil
+      stmt_stat hash_or_key
+    end
+
     private
     # A convenience method for obtaining the metadata about the query. Note
     # that this will actually execute the SQL, which means it can be a

--- a/lib/sqlite3/statement.rb
+++ b/lib/sqlite3/statement.rb
@@ -164,8 +164,12 @@ module SQLite3
     # a find, and thus the join step had to be processed as normal
     #   - +filter_hits+: the number of times that a join step was bypassed
     # because a Bloom filter returned not-found
-    def stat hash_or_key = nil
-      stmt_stat hash_or_key
+    def stat key = nil
+      if key
+        stat_for(key)
+      else
+        stats_as_hash
+      end
     end
 
     private

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -293,24 +293,23 @@ module SQLite3
         @db.execute 'INSERT INTO test_table (name) VALUES (?)', "name_#{i}"
       end
       @db.execute 'DROP INDEX IF EXISTS idx_test_table_id;'
-
       stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE 'name%'")
       stmt.execute.to_a
+
       assert_equal 9, stmt.fullscan_steps
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_sorts
       @db.execute 'CREATE TABLE test1(a)'
       @db.execute 'INSERT INTO test1 VALUES (1)'
-
       stmt = @db.prepare('select * from test1 order by a')
       stmt.execute.to_a
 
       assert_equal 1, stmt.sorts
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_autoindexes
@@ -320,93 +319,103 @@ module SQLite3
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
         @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i, i.to_s]
       end
-
       stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
       stmt.execute.to_a
+
       assert_equal 9, stmt.autoindexes
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_vm_steps
       @db.execute 'CREATE TABLE test1(a)'
       @db.execute 'INSERT INTO test1 VALUES (1)'
-
       stmt = @db.prepare('select * from test1 order by a')
       stmt.execute.to_a
 
       assert_equal 17, stmt.vm_steps
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_reprepares
+      stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE ?")
+
+      skip("reprepares not defined") unless stmt.respond_to?(:reprepares)
+
       @db.execute 'CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT);'
       10.times do |i|
         @db.execute 'INSERT INTO test_table (name) VALUES (?)', "name_#{i}"
       end
-
-      stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE ?")
       stmt.execute('name%').to_a
 
       assert_equal 1, stmt.reprepares
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_runs
+      stmt = @db.prepare('select * from test1')
+
+      skip("runs not defined") unless stmt.respond_to?(:runs)
+
       @db.execute 'CREATE TABLE test1(a)'
       @db.execute 'INSERT INTO test1 VALUES (1)'
-
-      stmt = @db.prepare('select * from test1')
       stmt.execute.to_a
 
       assert_equal 1, stmt.runs
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_filter_misses
+      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
+
+      skip("filter_misses not defined") unless stmt.respond_to?(:filter_misses)
+
       @db.execute "CREATE TABLE t1(a,b);"
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
         @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i, i.to_s]
       end
-      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
       stmt.execute.to_a
 
       assert_equal 10, stmt.filter_misses
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_filter_hits
+      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c AND b = '1' AND d = '1';")
+
+      skip("filter_hits not defined") unless stmt.respond_to?(:filter_hits)
+
       @db.execute "CREATE TABLE t1(a,b);"
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
         @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i+1, i.to_s]
       end
-
-      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c AND b = '1' AND d = '1';")
       stmt.execute.to_a
 
       assert_equal 1, stmt.filter_hits
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
 
     def test_memused
+      stmt = @db.prepare('select * from test1')
+
+      skip("memused not defined") unless stmt.respond_to?(:memused)
+
       @db.execute 'CREATE TABLE test1(a)'
       @db.execute 'INSERT INTO test1 VALUES (1)'
-
-      stmt = @db.prepare('select * from test1')
       stmt.execute.to_a
 
       assert_operator stmt.memused, :>, 0
-    ensure
-      stmt.close if stmt
+
+      stmt.close
     end
   end
 end

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -298,7 +298,7 @@ module SQLite3
       stmt.execute.to_a
       assert_equal 9, stmt.fullscan_steps
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
     def test_sorts
@@ -310,10 +310,10 @@ module SQLite3
 
       assert_equal 1, stmt.sorts
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
-    def test_auto_indexes
+    def test_autoindexes
       @db.execute "CREATE TABLE t1(a,b);"
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
@@ -323,7 +323,7 @@ module SQLite3
 
       stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
       stmt.execute.to_a
-      assert_equal 9, stmt.auto_indexes
+      assert_equal 9, stmt.autoindexes
     ensure
       stmt.close if stmt
     end
@@ -337,10 +337,10 @@ module SQLite3
 
       assert_equal 17, stmt.vm_steps
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
-    def test_re_prepares
+    def test_reprepares
       @db.execute 'CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT);'
       10.times do |i|
         @db.execute 'INSERT INTO test_table (name) VALUES (?)', "name_#{i}"
@@ -349,7 +349,7 @@ module SQLite3
       stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE ?")
       stmt.execute('name%').to_a
 
-      assert_equal 1, stmt.re_prepares
+      assert_equal 1, stmt.reprepares
     ensure
       stmt.close if stmt
     end
@@ -363,7 +363,7 @@ module SQLite3
 
       assert_equal 1, stmt.runs
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
     def test_filter_misses
@@ -378,7 +378,7 @@ module SQLite3
 
       assert_equal 10, stmt.filter_misses
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
     def test_filter_hits
@@ -386,7 +386,7 @@ module SQLite3
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
-        @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i, i.to_s]
+        @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i+1, i.to_s]
       end
 
       stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c AND b = '1' AND d = '1';")
@@ -394,19 +394,19 @@ module SQLite3
 
       assert_equal 1, stmt.filter_hits
     ensure
-      stmt.close
+      stmt.close if stmt
     end
 
-    def test_memory_used
+    def test_memused
       @db.execute 'CREATE TABLE test1(a)'
       @db.execute 'INSERT INTO test1 VALUES (1)'
 
       stmt = @db.prepare('select * from test1')
       stmt.execute.to_a
 
-      assert_equal 2784, stmt.memory_used
+      assert_equal 2784, stmt.memused
     ensure
-      stmt.close
+      stmt.close if stmt
     end
   end
 end

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -339,14 +339,14 @@ module SQLite3
     end
 
     def test_reprepares
-      stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE ?")
-
-      skip("reprepares not defined") unless stmt.respond_to?(:reprepares)
-
       @db.execute 'CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT);'
       10.times do |i|
         @db.execute 'INSERT INTO test_table (name) VALUES (?)', "name_#{i}"
       end
+      stmt = @db.prepare("SELECT * FROM test_table WHERE name LIKE ?")
+
+      skip("reprepares not defined") unless stmt.respond_to?(:reprepares)
+
       stmt.execute('name%').to_a
 
       assert_equal 1, stmt.reprepares
@@ -355,12 +355,12 @@ module SQLite3
     end
 
     def test_runs
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
       stmt = @db.prepare('select * from test1')
 
       skip("runs not defined") unless stmt.respond_to?(:runs)
 
-      @db.execute 'CREATE TABLE test1(a)'
-      @db.execute 'INSERT INTO test1 VALUES (1)'
       stmt.execute.to_a
 
       assert_equal 1, stmt.runs
@@ -369,16 +369,16 @@ module SQLite3
     end
 
     def test_filter_misses
-      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
-
-      skip("filter_misses not defined") unless stmt.respond_to?(:filter_misses)
-
       @db.execute "CREATE TABLE t1(a,b);"
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
         @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i, i.to_s]
       end
+      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c;")
+
+      skip("filter_misses not defined") unless stmt.respond_to?(:filter_misses)
+
       stmt.execute.to_a
 
       assert_equal 10, stmt.filter_misses
@@ -387,16 +387,16 @@ module SQLite3
     end
 
     def test_filter_hits
-      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c AND b = '1' AND d = '1';")
-
-      skip("filter_hits not defined") unless stmt.respond_to?(:filter_hits)
-
       @db.execute "CREATE TABLE t1(a,b);"
       @db.execute "CREATE TABLE t2(c,d);"
       10.times do |i|
         @db.execute 'INSERT INTO t1 (a, b) VALUES (?, ?)', [i, i.to_s]
         @db.execute 'INSERT INTO t2 (c, d) VALUES (?, ?)', [i+1, i.to_s]
       end
+      stmt = @db.prepare("SELECT * FROM t1, t2 WHERE a=c AND b = '1' AND d = '1';")
+
+      skip("filter_hits not defined") unless stmt.respond_to?(:filter_hits)
+
       stmt.execute.to_a
 
       assert_equal 1, stmt.filter_hits
@@ -405,12 +405,12 @@ module SQLite3
     end
 
     def test_memused
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
       stmt = @db.prepare('select * from test1')
 
       skip("memused not defined") unless stmt.respond_to?(:memused)
 
-      @db.execute 'CREATE TABLE test1(a)'
-      @db.execute 'INSERT INTO test1 VALUES (1)'
       stmt.execute.to_a
 
       assert_operator stmt.memused, :>, 0

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -404,7 +404,7 @@ module SQLite3
       stmt = @db.prepare('select * from test1')
       stmt.execute.to_a
 
-      assert_equal 2784, stmt.memused
+      assert_operator stmt.memused, :>, 0
     ensure
       stmt.close if stmt
     end

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -333,7 +333,7 @@ module SQLite3
       stmt = @db.prepare('select * from test1 order by a')
       stmt.execute.to_a
 
-      assert_equal 17, stmt.vm_steps
+      assert_operator stmt.vm_steps, :>, 0
 
       stmt.close
     end

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -286,5 +286,112 @@ module SQLite3
 
       stmt.close
     end
+
+    def test_fullscan_steps
+      @db.execute 'CREATE TABLE test1(a, b)'
+      @db.execute 'INSERT INTO test1 VALUES ("hello", "world")'
+
+      stmt = @db.prepare('select * from test1 where b like "%orld"')
+      p stmt.execute.to_a
+      assert_equal 3, stmt.fullscan_steps
+    ensure
+      stmt.close
+    end
+
+    def test_sorts
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1 order by a')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.sorts
+    ensure
+      stmt.close
+    end
+
+    def test_auto_indexes
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1 order by a')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.auto_indexes
+    ensure
+      stmt.close
+    end
+
+    def test_vm_steps
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1 order by a')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.vm_steps
+    ensure
+      stmt.close
+    end
+
+    def test_re_prepares
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1 order by a')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.re_prepares
+    ensure
+      stmt.close
+    end
+
+    def test_runs
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.runs
+    ensure
+      stmt.close
+    end
+
+    def test_filter_misses
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.filter_misses
+    ensure
+      stmt.close
+    end
+
+    def test_filter_hits
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.filter_hits
+    ensure
+      stmt.close
+    end
+
+    def test_memory_used
+      @db.execute 'CREATE TABLE test1(a)'
+      @db.execute 'INSERT INTO test1 VALUES (1)'
+
+      stmt = @db.prepare('select * from test1')
+      stmt.execute.to_a
+
+      assert_equal 1, stmt.memory_used
+    ensure
+      stmt.close
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/sparklemotion/sqlite3-ruby/issues/410

This PR adds 9 instance methods to the `Statement` class:

* `fullscan_steps`
* `sorts`
* `autoindexes`
* `vm_steps`
* `reprepares`
* `runs`
* `filter_misses`
* `filter_hits`
* `memused`

Each method corresponds to one of the [counters](https://www.sqlite.org/c3ref/c_stmtstatus_counter.html) available to the [`stmt_status`](https://www.sqlite.org/c3ref/stmt_status.html) interface. 

I wasn't sure how best to name the methods. There were two paths I considered: either mapping from the counter constant names or trying to find the clearest, most semantic name for the value. I decided to go with path one as this should make searching for methods from SQLite reference easier. We could add method aliases if we want to add more semantic method names.

