### PR TITLE
Use a factory method to eliminate "results as hash" check

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -224,7 +224,7 @@ module SQLite3
 
       prepare(sql) do |stmt|
         stmt.bind_params(bind_vars)
-        stmt = ResultSet.new self, stmt
+        stmt = build_result_set stmt
 
         if block
           stmt.each do |row|
@@ -744,6 +744,17 @@ module SQLite3
     # Translates a +row+ of data from the database with the given +types+
     def translate_from_db types, row
       @type_translator.call types, row
+    end
+
+    # Given a statement, return a result set.
+    # This is not intended for general consumption
+    # :nodoc:
+    def build_result_set stmt
+      if results_as_hash
+        HashResultSet.new(self, stmt)
+      else
+        ResultSet.new(self, stmt)
+      end
     end
 
     private

--- a/lib/sqlite3/resultset.rb
+++ b/lib/sqlite3/resultset.rb
@@ -92,10 +92,6 @@ module SQLite3
     # For hashes, the column names are the keys of the hash, and the column
     # types are accessible via the +types+ property.
     def next
-      if @db.results_as_hash
-        return next_hash
-      end
-
       row = @stmt.step
       return nil if @stmt.done?
 
@@ -174,5 +170,9 @@ module SQLite3
       row.types = @stmt.types
       row
     end
+  end
+
+  class HashResultSet < ResultSet # :nodoc:
+    alias :next :next_hash
   end
 end

--- a/lib/sqlite3/statement.rb
+++ b/lib/sqlite3/statement.rb
@@ -79,12 +79,12 @@ module SQLite3
       reset! if active? || done?
 
       bind_params(*bind_vars) unless bind_vars.empty?
-      @results = ResultSet.new(@connection, self)
+      results = @connection.build_result_set self
 
       step if column_count == 0
 
-      yield @results if block_given?
-      @results
+      yield results if block_given?
+      results
     end
 
     # Execute the statement. If no block was given, this returns an array of

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -97,6 +97,7 @@ class IntegrationResultSetTestCase < SQLite3::TestCase
 
   def test_next_results_as_hash
     @db.results_as_hash = true
+    @result = @stmt.execute
     @result.reset(1)
     hash = @result.next
     assert_equal({"a" => 1, "b" => "foo"},


### PR DESCRIPTION
"Results as hash" should be set on the database, so we should only need to check it once when we first start the query.  This patch pulls result set construction in to a factory method on the database object.  Doing this eliminates a "translate to hash" check that is performed on every row fetch.