### PR TITLE
Remove row array wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,22 @@ db.prepare("SELECT * FROM items") do |stmt|
 end
 ```
 
+- Removed `types` and `fields` readers on row objects.
+  Deprecated code looks like this:
+
+```ruby
+row = @db.execute("select * from foo")
+assert_equal ["blob"], row.first.types
+```
+
+  If you would like to access the "types" associated with a returned query,
+  use a prepared statement like this:
+
+```ruby
+@db.prepare("select * from foo") do |v|
+  assert_equal ["blob"], v.types
+end
+```
 
 ## 1.7.0 / 2023-12-27
 

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -676,7 +676,7 @@ module SQLite3
     # but only retries up to the indicated number of +milliseconds+.
     # This is an alternative to #busy_timeout, which holds the GVL
     # while SQLite sleeps and retries.
-    def busy_handler_timeout=( milliseconds )
+    def busy_handler_timeout=(milliseconds)
       timeout_seconds = milliseconds.fdiv(1000)
 
       busy_handler do |count|

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -136,12 +136,10 @@ module SQLite3
       stmt = SQLite3::Statement.new(@db, "insert into foo(text) values (?)")
       stmt.bind_param(1, SQLite3::Blob.new("hello"))
       stmt.execute
-      row = @db.execute("select * from foo")
       stmt.close
-
-      assert_equal ["hello"], row.first
-      capture_io do # hush deprecation warning
-        assert_equal ["blob"], row.first.types
+      @db.prepare("select * from foo") do |v|
+        assert_equal ["hello"], v.first
+        assert_equal ["blob"], v.types
       end
     end
 


### PR DESCRIPTION
This commit removes deprecated row array wrappers.  If you want to access "types" for a particular query, then use a prepared statement.

Deprecated / removed code looks like this:

```ruby
row = @db.execute("select * from foo")
assert_equal ["blob"], row.first.types
```

If you would like to access the "types" associated with a returned query, use a prepared statement like this:

```ruby
@db.prepare("select * from foo") do |v|
  assert_equal ["blob"], v.types
end

```