### PR TITLE
Implement GVL-releasing, backing-off busy_timeout

### DIFF
--- a/ext/sqlite3/database.h
+++ b/ext/sqlite3/database.h
@@ -6,6 +6,7 @@
 struct _sqlite3Ruby {
     sqlite3 *db;
     VALUE busy_handler;
+    int busy_timeout;
 };
 
 typedef struct _sqlite3Ruby sqlite3Ruby;


### PR DESCRIPTION
After getting a tad more experienced with the C portion of this codebase, I decided to try and see if I could implement the logic of SQLite's `busy_timeout` (with its backoff logic) in the extension such that we could release the GVL while sleeping. You can find SQLite's implementation of `sqlite3_busy_timeout` [here](https://github.com/sqlite/sqlite/blob/e5b2132df69e43ebe51df3a400dc2aba24f5fd29/src/main.c#L1835) and the default callback functionality [here](https://github.com/sqlite/sqlite/blob/e5b2132df69e43ebe51df3a400dc2aba24f5fd29/src/main.c#L1713). 

I think this is a good start, but I am stumped because when I try to compile, I get this error:
```
error: implicit declaration of function 'rb_thread_call_without_gvl' is invalid in C99
```

I'm not certain why this method isn't available, but how can I sleep and release the GVL here in C-land? Any help on this would be greatly appreciated. (note: I see from CI that this method is only missing in `darwin` environments. Interesting)

cc @suwyn who originally challenged me to do this in C-land.