### PR TITLE
Freeze results that come from the database

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -162,6 +162,7 @@ step(VALUE self)
                         if (internal_encoding) {
                             val = rb_str_export_to_enc(val, internal_encoding);
                         }
+                        rb_obj_freeze(val);
                     }
                     break;
                     case SQLITE_BLOB: {
@@ -169,6 +170,7 @@ step(VALUE self)
                                   (const char *)sqlite3_column_blob(stmt, i),
                                   (long)sqlite3_column_bytes(stmt, i)
                               );
+                        rb_obj_freeze(val);
                     }
                     break;
                     case SQLITE_NULL:
@@ -191,6 +193,8 @@ step(VALUE self)
             ctx->done_p = 0;
             CHECK(sqlite3_db_handle(ctx->st), value);
     }
+
+    rb_obj_freeze(list);
 
     return list;
 }

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -208,7 +208,7 @@ module SQLite3
             yield row
           end
         else
-          stmt.to_a
+          stmt.to_a.freeze
         end
       end
     end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -82,7 +82,7 @@ module SQLite3
 
       string = @db.execute("select data from foo").first.first
       assert_equal Encoding.find("ASCII-8BIT"), string.encoding
-      assert_equal str, string.force_encoding("UTF-8")
+      assert_equal str, string.dup.force_encoding("UTF-8")
     end
 
     def test_blob_is_ascii8bit
@@ -95,7 +95,7 @@ module SQLite3
 
       string = @db.execute("select data from foo").first.first
       assert_equal Encoding.find("ASCII-8BIT"), string.encoding
-      assert_equal str, string.force_encoding("UTF-8")
+      assert_equal str, string.dup.force_encoding("UTF-8")
     end
 
     def test_blob_with_eucjp
@@ -108,7 +108,7 @@ module SQLite3
 
       string = @db.execute("select data from foo").first.first
       assert_equal Encoding.find("ASCII-8BIT"), string.encoding
-      assert_equal str, string.force_encoding("EUC-JP")
+      assert_equal str, string.dup.force_encoding("EUC-JP")
     end
 
     def test_db_with_eucjp

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -25,8 +25,10 @@ module SQLite3
       assert_predicate row, :frozen?
       row.each { |item| assert_predicate item, :frozen? }
 
-      assert Ractor.shareable?(rows)
-      assert Ractor.shareable?(row)
+      if defined?(Ractor)
+        assert Ractor.shareable?(rows)
+        assert Ractor.shareable?(row)
+      end
     end
 
     def test_double_close_does_not_segv


### PR DESCRIPTION
Freeze strings and row records so that we can more easily share results among Ractors

Silly example, but here's an example of using database results plus Ractors to make a parallel producer-consumer pattern:

```ruby
require "sqlite3"
require "securerandom"

def fib n
  if n < 2
    n
  else
    fib(n-2) + fib(n-1)
  end
end

N = 10

# Make a Ractor safe queue that supports N workers
queue = Ractor.new do
  while (work = Ractor.receive)
    Ractor.yield work
  end
  # Shutdown the workers
  N.times { Ractor.yield nil }
end

# Spin up workers
workers = N.times.map do
  Ractor.new(queue) do |q|
    while (work = q.take)
      name, i = work
      p "Ractor: #{Ractor.current} #{name}: #{fib(i)}"
    end
  end
end

db = SQLite3::Database.new ":memory:"
db.execute 'CREATE TABLE "fibs" (name string, fib int)'
stmt = db.prepare "INSERT INTO fibs (name, fib) VALUES (?, ?)"
5000.times { stmt.execute SecureRandom.hex, rand(30) }
stmt.close

stmt = db.prepare 'SELECT name, fib FROM fibs'

# Send work from the database to the queue
stmt.each { |row| queue.send row }

stmt.close

# Tell the queue we've sent all the work
queue.send nil

# Wait for workers to finish
workers.map(&:take)
```