### PR TITLE
Ensure the `Database#encoding` method works when results are "as hash"

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -138,7 +138,9 @@ module SQLite3
     #
     # Fetch the encoding set on this database
     def encoding
-      @encoding ||= Encoding.find(execute("PRAGMA encoding").first.first)
+      @encoding ||= prepare("PRAGMA encoding") { |stmt|
+        Encoding.find(stmt.first.first)
+      }
     end
 
     # Installs (or removes) a block that will be invoked for every access

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -13,6 +13,14 @@ module SQLite3
       @db.close
     end
 
+    def test_encoding_when_results_are_hash
+      db = SQLite3::Database.new(":memory:", results_as_hash: true)
+      assert_equal Encoding.find("UTF-8"), db.encoding
+
+      db = SQLite3::Database.new(":memory:")
+      assert_equal Encoding.find("UTF-8"), db.encoding
+    end
+
     def test_select_encoding_on_utf_16
       str = "foo"
       utf16 = ([1].pack("I") == [1].pack("N")) ? "UTF-16BE" : "UTF-16LE"


### PR DESCRIPTION
This is a regression test for Rails. Rails instantiates SQLite3 with `results_as_hash` set to `true` by default. I broke the encoding method when that value is set to true, so this patch fixes it.