### PR TITLE
dep: update vendored sqlite to 3.45.0 (main)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 6c427f0547e2f7babe636b748dd5d5a1f2f31601adadef7e2805e7d1f7171861
+  # 9fc2a78088875ae7c112957d58ccc52b1a0a4afa34ac669290be42f352b1aa76
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3440200.tar.gz
-  # 6c427f0547e2f7babe636b748dd5d5a1f2f31601adadef7e2805e7d1f7171861  ports/archives/sqlite-autoconf-3440200.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450000.tar.gz
+  # 9fc2a78088875ae7c112957d58ccc52b1a0a4afa34ac669290be42f352b1aa76  ports/archives/sqlite-autoconf-3450000.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3440200.tar.gz
-  # 1c6719a148bc41cf0f2bbbe3926d7ce3f5ca09d878f1246fcc20767b175bb407  ports/archives/sqlite-autoconf-3440200.tar.gz
-  version: "3.44.2"
+  # $ sha256sum ports/archives/sqlite-autoconf-3450000.tar.gz
+  # 72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436  ports/archives/sqlite-autoconf-3450000.tar.gz
+  version: "3.45.0"
   files:
-    - url: "https://sqlite.org/2023/sqlite-autoconf-3440200.tar.gz"
-      sha256: "1c6719a148bc41cf0f2bbbe3926d7ce3f5ca09d878f1246fcc20767b175bb407"
+    - url: "https://sqlite.org/2024/sqlite-autoconf-3450000.tar.gz"
+      sha256: "72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436"


### PR DESCRIPTION
https://www.sqlite.org/releaselog/3_45_0.html

Note that CHANGELOG entry will be forward-ported later from the 1.7.x release branch.