### PR TITLE
Don't cache the database encoding

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -117,7 +117,6 @@ module SQLite3
 
       @tracefunc = nil
       @authorizer = nil
-      @encoding = nil
       @busy_handler = nil
       @collations = {}
       @functions = {}
@@ -138,9 +137,7 @@ module SQLite3
     #
     # Fetch the encoding set on this database
     def encoding
-      @encoding ||= prepare("PRAGMA encoding") { |stmt|
-        Encoding.find(stmt.first.first)
-      }
+      prepare("PRAGMA encoding") { |stmt| Encoding.find(stmt.first.first) }
     end
 
     # Installs (or removes) a block that will be invoked for every access

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -13,6 +13,14 @@ module SQLite3
       @db.close
     end
 
+    def test_change_encoding
+      db = SQLite3::Database.new(":memory:")
+      assert_equal Encoding.find("UTF-8"), db.encoding
+
+      db.execute "PRAGMA encoding='UTF-16le'"
+      assert_equal Encoding.find("UTF-16le"), db.encoding
+    end
+
     def test_encoding_when_results_are_hash
       db = SQLite3::Database.new(":memory:", results_as_hash: true)
       assert_equal Encoding.find("UTF-8"), db.encoding


### PR DESCRIPTION
Database encoding can be changed, and we don't want to intercept all queries just to check if someone changed the encoding. This commit removes the encoding cache. If applications find that they are querying the database encoding frequently, they should cache the return value of this method themselves