### PR TITLE
Intern column names so we always get the same string

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -109,6 +109,10 @@ module Sqlite3
 
         abort_could_not_find(libname) unless find_library(libname, "sqlite3_libversion_number", "sqlite3.h")
 
+        # Truffle Ruby doesn't support this yet:
+        # https://github.com/oracle/truffleruby/issues/3408
+        have_func("rb_enc_interned_str_cstr")
+
         # Functions defined in 1.9 but not 1.8
         have_func("rb_proc_arity")
 

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -364,6 +364,22 @@ column_count(VALUE self)
     return INT2NUM(sqlite3_column_count(ctx->st));
 }
 
+#if HAVE_RB_ENC_INTERNED_STR_CSTR
+static VALUE
+interned_utf8_cstr(const char * str)
+{
+    return rb_enc_interned_str_cstr(str, rb_utf8_encoding());
+}
+#else
+static VALUE
+interned_utf8_cstr(const char * str)
+{
+    VALUE rb_str = rb_utf8_str_new_cstr(str);
+    rb_obj_freeze(rb_str);
+    return rb_funcall(rb_str, rb_intern("-@"), 0);
+}
+#endif
+
 /* call-seq: stmt.column_name(index)
  *
  * Get the column name at +index+.  0 based.
@@ -382,8 +398,7 @@ column_name(VALUE self, VALUE index)
     VALUE ret = Qnil;
 
     if (name) {
-        ret = SQLITE3_UTF8_STR_NEW2(name);
-        rb_obj_freeze(ret);
+        ret = interned_utf8_cstr(name);
     }
     return ret;
 }

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -366,16 +366,15 @@ column_count(VALUE self)
 
 #if HAVE_RB_ENC_INTERNED_STR_CSTR
 static VALUE
-interned_utf8_cstr(const char * str)
+interned_utf8_cstr(const char *str)
 {
     return rb_enc_interned_str_cstr(str, rb_utf8_encoding());
 }
 #else
 static VALUE
-interned_utf8_cstr(const char * str)
+interned_utf8_cstr(const char *str)
 {
     VALUE rb_str = rb_utf8_str_new_cstr(str);
-    rb_obj_freeze(rb_str);
     return rb_funcall(rb_str, rb_intern("-@"), 0);
 }
 #endif

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -58,6 +58,7 @@ module SQLite3
       stmt = @db.prepare "SELECT float, int, text, string, nil FROM things"
       # Make sure this new statement returns the same interned strings
       stmt.columns.each_with_index do |str, i|
+        assert_predicate columns[i], :frozen?
         assert_same columns[i], str
       end
     ensure


### PR DESCRIPTION
When we get column names back from the database, it's very common to always return the same strings. This patch uses Ruby's "interned string" API so that we're always getting the same string objects back from the database.

Fixes: #155