### PR TITLE
dep: update vendored sqlite to 3.45.1 (main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,18 @@ assert_equal ["blob"], row.first.types
 end
 ```
 
+## 1.7.2 / 2024-01-30
+
+### Dependencies
+
+- Vendored sqlite is updated to [v3.45.1](https://www.sqlite.org/releaselog/3_45_1.html). @flavorjones
+
+
 ## 1.7.1 / 2024-01-24
 
 ### Dependencies
 
-- Vendored sqlite is update to [v3.45.0](https://www.sqlite.org/releaselog/3_45_0.html). @flavorjones
+- Vendored sqlite is updated to [v3.45.0](https://www.sqlite.org/releaselog/3_45_0.html). @flavorjones
 
 
 ## 1.7.0 / 2023-12-27

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 9fc2a78088875ae7c112957d58ccc52b1a0a4afa34ac669290be42f352b1aa76
+  # a54395aa2cf76b5b973fa420715b6108afedc4d8c0209c763fd2c1b517f8ad9f
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450000.tar.gz
-  # 9fc2a78088875ae7c112957d58ccc52b1a0a4afa34ac669290be42f352b1aa76  ports/archives/sqlite-autoconf-3450000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450100.tar.gz
+  # a54395aa2cf76b5b973fa420715b6108afedc4d8c0209c763fd2c1b517f8ad9f  ports/archives/sqlite-autoconf-3450100.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3450000.tar.gz
-  # 72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436  ports/archives/sqlite-autoconf-3450000.tar.gz
-  version: "3.45.0"
+  # $ sha256sum ports/archives/sqlite-autoconf-3450100.tar.gz
+  # cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a  ports/archives/sqlite-autoconf-3450100.tar.gz
+  version: "3.45.1"
   files:
-    - url: "https://sqlite.org/2024/sqlite-autoconf-3450000.tar.gz"
-      sha256: "72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436"
+    - url: "https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz"
+      sha256: "cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a"


### PR DESCRIPTION
https://www.sqlite.org/releaselog/3_45_1.html

(cherry-picked from e9bfbdbe on 1-7-stable)