### PR TITLE
fix: expanded sql leak

### DIFF
--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -102,16 +102,16 @@ rb_sqlite3_raise(sqlite3 *db, int status)
  *  accepts a sqlite3 error message as the final argument, which will be `sqlite3_free`d
  */
 void
-rb_sqlite3_raise_msg(sqlite3 *db, int status, const char* msg)
+rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg)
 {
-  VALUE exception;
+    VALUE exception;
 
-  if (status == SQLITE_OK) {
-    return;
-  }
+    if (status == SQLITE_OK) {
+        return;
+    }
 
-  exception = rb_exc_new2(rb_path2class("SQLite3::Exception"), msg);
-  sqlite3_free((void*)msg);
-  rb_iv_set(exception, "@code", INT2FIX(status));
-  rb_exc_raise(exception);
+    exception = rb_exc_new2(rb_path2class("SQLite3::Exception"), msg);
+    sqlite3_free((void *)msg);
+    rb_iv_set(exception, "@code", INT2FIX(status));
+    rb_exc_raise(exception);
 }

--- a/ext/sqlite3/exception.h
+++ b/ext/sqlite3/exception.h
@@ -5,6 +5,6 @@
 #define CHECK_MSG(_db, _status, _msg) rb_sqlite3_raise_msg(_db, _status, _msg);
 
 void rb_sqlite3_raise(sqlite3 *db, int status);
-void rb_sqlite3_raise_msg(sqlite3 *db, int status, const char* msg);
+void rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg);
 
 #endif

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -622,10 +622,17 @@ static VALUE
 get_expanded_sql(VALUE self)
 {
     sqlite3StmtRubyPtr ctx;
+    char *expanded_sql;
+    VALUE rb_expanded_sql;
+
     TypedData_Get_Struct(self, sqlite3StmtRuby, &statement_type, ctx);
     REQUIRE_OPEN_STMT(ctx);
 
-    return rb_obj_freeze(SQLITE3_UTF8_STR_NEW2(sqlite3_expanded_sql(ctx->st)));
+    expanded_sql = sqlite3_expanded_sql(ctx->st);
+    rb_expanded_sql = rb_obj_freeze(SQLITE3_UTF8_STR_NEW2(expanded_sql));
+    sqlite3_free(expanded_sql);
+
+    return rb_expanded_sql;
 }
 
 void


### PR DESCRIPTION
cc @tenderlove 

This actually was caught by the test suite in https://github.com/sparklemotion/sqlite3-ruby/actions/runs/7745352446/job/21121203412#step:6:82 but I missed it because we've been having some flaky failures of the valgrind/memcheck suite (see https://github.com/sparklemotion/sqlite3-ruby/issues/489).