### PR TITLE
Remove FunctionProxy#count

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -725,13 +725,6 @@ module SQLite3
         @driver.result_error(@func, error.to_s, -1)
       end
 
-      # (Only available to aggregate functions.) Returns the number of rows
-      # that the aggregate has processed so far. This will include the current
-      # row, and so will always return at least 1.
-      def count
-        @driver.aggregate_count(@func)
-      end
-
       # Returns the value with the given key from the context. This is only
       # available to aggregate functions.
       def [](key)


### PR DESCRIPTION
This code depends on a SQLite API which is deprecated, `sqlite3_aggregate_count` ([docs](https://www.sqlite.org/c3ref/aggregate_count.html)). In addition, the present implementation is broken (`@driver` is always nil). Related: #164.

## Note to reviewers

[This check](https://github.com/sparklemotion/sqlite3-ruby/actions/runs/8106559146/job/22156728792?pr=509) failed and appears unrelated to this code change.