### PR TITLE
execute_batch returns result of last statement

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -251,8 +251,7 @@ module SQLite3
     # in turn. The same bind parameters, if given, will be applied to each
     # statement.
     #
-    # This always returns +nil+, making it unsuitable for queries that return
-    # rows.
+    # This always returns the result of the last statement.
     #
     # See also #execute_batch2 for additional ways of
     # executing statements.
@@ -279,6 +278,7 @@ module SQLite3
       end
 
       sql = sql.strip
+      result = nil
       until sql.empty?
         prepare(sql) do |stmt|
           unless stmt.closed?
@@ -287,13 +287,13 @@ module SQLite3
             if bind_vars.length == stmt.bind_parameter_count
               stmt.bind_params(bind_vars)
             end
-            stmt.step
+            result = stmt.step
           end
           sql = stmt.remainder.strip
         end
       end
-      # FIXME: we should not return `nil` as a success return value
-      nil
+
+      result
     end
 
     # Executes all SQL statements in the given string. By contrast, the other

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -145,11 +145,19 @@ module SQLite3
     end
 
     def test_batch_last_comment_is_processed
-      # FIXME: nil as a successful return value is kinda dumb
       assert_nil @db.execute_batch <<-EOSQL
         CREATE TABLE items (id integer PRIMARY KEY AUTOINCREMENT);
         -- omg
       EOSQL
+    end
+
+    def test_batch_last_expression_value_is_returned
+      batch = <<-EOSQL
+        CREATE TABLE items (id integer PRIMARY KEY AUTOINCREMENT);
+        SELECT COUNT(*) FROM items;
+      EOSQL
+
+      assert_equal [0], @db.execute_batch(batch)
     end
 
     def test_execute_batch2


### PR DESCRIPTION
This is part of what's requested in https://github.com/sparklemotion/sqlite3-ruby/issues/243. (The other part is to take an array of statements, but that is not implemented here.)