### PR TITLE
dep: update sqlite to 3.45.2 (1-7-stable branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sqlite3-ruby Changelog
 
+## 1.7.3 / 2024-03-15
+
+### Dependencies
+
+- Vendored sqlite is updated to [v3.45.2](https://www.sqlite.org/releaselog/3_45_2.html). @flavorjones
+
+
 ## 1.7.2 / 2024-01-30
 
 ### Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,14 +1,14 @@
 # TODO: stop using symbols here once we no longer support Ruby 2.7 and can rely on symbolize_names
 :sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # a54395aa2cf76b5b973fa420715b6108afedc4d8c0209c763fd2c1b517f8ad9f
+  # 1b02c58a711d15b50da8a1089e0f8807ebbdf3e674c714100eda9a03a69ac758
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450100.tar.gz
-  # a54395aa2cf76b5b973fa420715b6108afedc4d8c0209c763fd2c1b517f8ad9f  ports/archives/sqlite-autoconf-3450100.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450200.tar.gz
+  # 1b02c58a711d15b50da8a1089e0f8807ebbdf3e674c714100eda9a03a69ac758  ports/archives/sqlite-autoconf-3450200.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3450100.tar.gz
-  # cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a  ports/archives/sqlite-autoconf-3450100.tar.gz
-  :version: "3.45.1"
+  # $ sha256sum ports/archives/sqlite-autoconf-3450200.tar.gz
+  # bc9067442eedf3dd39989b5c5cfbfff37ae66cc9c99274e0c3052dc4d4a8f6ae  ports/archives/sqlite-autoconf-3450200.tar.gz
+  :version: "3.45.2"
   :files:
-    - :url: "https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz"
-      :sha256: "cd9c27841b7a5932c9897651e20b86c701dd740556989b01ca596fcfa3d49a0a"
+    - :url: "https://sqlite.org/2024/sqlite-autoconf-3450200.tar.gz"
+      :sha256: "bc9067442eedf3dd39989b5c5cfbfff37ae66cc9c99274e0c3052dc4d4a8f6ae"


### PR DESCRIPTION
https://sqlite.org/releaselog/3_45_2.html