### PR TITLE
dep: update sqlite3 to 3.45.3 from 3.45.2

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 1b02c58a711d15b50da8a1089e0f8807ebbdf3e674c714100eda9a03a69ac758
+  # cc1050780e0266de4d91b31c8deaf4638336908c12c21898e9f1fcae1e2ac303
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450200.tar.gz
-  # 1b02c58a711d15b50da8a1089e0f8807ebbdf3e674c714100eda9a03a69ac758  ports/archives/sqlite-autoconf-3450200.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3450300.tar.gz
+  # cc1050780e0266de4d91b31c8deaf4638336908c12c21898e9f1fcae1e2ac303  ports/archives/sqlite-autoconf-3450300.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3450200.tar.gz
-  # bc9067442eedf3dd39989b5c5cfbfff37ae66cc9c99274e0c3052dc4d4a8f6ae  ports/archives/sqlite-autoconf-3450200.tar.gz
-  version: "3.45.2"
+  # $ sha256sum ports/archives/sqlite-autoconf-3450300.tar.gz
+  # b2809ca53124c19c60f42bf627736eae011afdcc205bb48270a5ee9a38191531  ports/archives/sqlite-autoconf-3450300.tar.gz
+  version: "3.45.3"
   files:
-    - url: "https://sqlite.org/2024/sqlite-autoconf-3450200.tar.gz"
-      sha256: "bc9067442eedf3dd39989b5c5cfbfff37ae66cc9c99274e0c3052dc4d4a8f6ae"
+    - url: "https://sqlite.org/2024/sqlite-autoconf-3450300.tar.gz"
+      sha256: "b2809ca53124c19c60f42bf627736eae011afdcc205bb48270a5ee9a38191531"


### PR DESCRIPTION
From the forum announcement:

> This is a patch release with minimal changes.  None of the problems fixed are critical so updating is not an emergency.  See the change log or the "news" page for details.

See also:

- https://sqlite.org/releaselog/3_45_3.html
- https://sqlite.org/src/timeline?from=version-3.45.2&to=version-3.45.3
