### PR TITLE
fix: Database#execute_batch properly handles non-ASCII strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Raise an exception if `Database#execute`, `#execute_batch`, or `#query` are passed multiple bind parameters that are not in an Array. In v2.0.0 these methods would silently swallow additional arguments. [#527] @flavorjones
+- Fixed a regression in v2.0.0 that caused `Database#execute_batch` to raise an encoding exception when passed some non-ascii strings. As a result of this fix, `Database#prepare` now ensures the "remainder" string will always be encoded as UTF-8. [#524] @flavorjones
 
 
 ## 2.0.0 / 2024-04-17

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -72,7 +72,7 @@ prepare(VALUE self, VALUE db, VALUE sql)
     CHECK(db_ctx->db, status);
     timespecclear(&db_ctx->stmt_deadline);
 
-    return rb_str_new2(tail);
+    return rb_utf8_str_new_cstr(tail);
 }
 
 /* call-seq: stmt.close

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -326,6 +326,24 @@ module SQLite3
       assert_equal :foo, r
     end
 
+    def test_prepare_batch_split
+      db = SQLite3::Database.new(":memory:")
+      s1 = db.prepare("select 'asdf'; select 'qwer'; select 'côté'")
+
+      assert_equal " select 'qwer'; select 'côté'", s1.remainder
+      assert_equal Encoding::UTF_8, s1.remainder.encoding
+
+      s2 = db.prepare(s1.remainder)
+
+      assert_equal " select 'côté'", s2.remainder
+      assert_equal Encoding::UTF_8, s2.remainder.encoding
+
+      s3 = db.prepare(s2.remainder)
+
+      assert_equal "", s3.remainder
+      assert_equal Encoding::UTF_8, s3.remainder.encoding
+    end
+
     def test_total_changes
       db = SQLite3::Database.new(":memory:")
       db.execute("create table foo ( a integer primary key, b text )")


### PR DESCRIPTION
Fix a regression in v2.0.0 that caused `Database#execute_batch` to raise an encoding exception when passed some non-ASCII strings. As a result of this fix, `Database#prepare` now ensures the "remainder" string will always be encoded as UTF-8.

Closes #524