### PR TITLE
fix: raise an exception if multiple bind parameters aren't an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sqlite3-ruby Changelog
 
+## next / unreleased
+
+### Fixed
+
+- Raise an exception if `Database#execute`, `#execute_batch`, or `#query` are passed multiple bind parameters that are not in an Array. In v2.0.0 these methods would silently swallow additional arguments. [#527] @flavorjones
+
+
 ## 2.0.0 / 2024-04-17
 
 This is a major release which contains some breaking changes, primarily the removal of

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -194,7 +194,7 @@ module SQLite3
     #
     # See also #execute2, #query, and #execute_batch for additional ways of
     # executing statements.
-    def execute sql, bind_vars = [], *args, &block
+    def execute sql, bind_vars = [], &block
       prepare(sql) do |stmt|
         stmt.bind_params(bind_vars)
         stmt = build_result_set stmt
@@ -243,7 +243,7 @@ module SQLite3
     #
     # See also #execute_batch2 for additional ways of
     # executing statements.
-    def execute_batch(sql, bind_vars = [], *args)
+    def execute_batch(sql, bind_vars = [])
       sql = sql.strip
       result = nil
       until sql.empty?
@@ -298,7 +298,7 @@ module SQLite3
     # returned, or you could have problems with locks on the table. If called
     # with a block, +close+ will be invoked implicitly when the block
     # terminates.
-    def query(sql, bind_vars = [], *args)
+    def query(sql, bind_vars = [])
       result = prepare(sql).execute(bind_vars)
       if block_given?
         begin

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -480,5 +480,19 @@ module SQLite3
 
       stmt.close
     end
+
+    def test_raise_if_bind_params_not_an_array
+      assert_raises(ArgumentError) do
+        @db.execute "SELECT * from table1 where a = ? and b = ?", 1, 2
+      end
+
+      assert_raises(ArgumentError) do
+        @db.query "SELECT * from table1 where a = ? and b = ?", 1, 2
+      end
+
+      assert_raises(ArgumentError) do
+        @db.execute_batch "SELECT * from table1 where a = ? and b = ?", 1, 2
+      end
+    end
   end
 end


### PR DESCRIPTION
Make sure Database#execute, #query, and #execute_batch raise an ArgumentError to avoid silent problems.

This should have been done in ae129046

Related to #525

A potential alternative is to revert ae129046