### PR TITLE
Proof of Concept: Release GVL in Statement#step

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -170,12 +170,26 @@ total_changes(VALUE self)
     return INT2NUM(sqlite3_total_changes(ctx->db));
 }
 
-static void
-tracefunc(void *data, const char *sql)
+struct tracefunc_args {
+    VALUE self;
+    const char *sql;
+};
+
+static void *
+tracefunc(void *nogvl_context)
 {
-    VALUE self = (VALUE)data;
-    VALUE thing = rb_iv_get(self, "@tracefunc");
-    rb_funcall(thing, rb_intern("call"), 1, rb_str_new2(sql));
+    struct tracefunc_args *args = nogvl_context;
+    VALUE thing = rb_iv_get(args->self, "@tracefunc");
+    rb_funcall(thing, rb_intern("call"), 1, rb_str_new2(args->sql));
+    return NULL;
+}
+
+static void
+tracefunc_nogvl(void *data, const char *sql)
+{
+    /* This probably also needs rb_protected */
+    struct tracefunc_args args = { (VALUE)data, sql };
+    rb_thread_call_with_gvl(tracefunc, &args);
 }
 
 /* call-seq:
@@ -201,18 +215,32 @@ trace(int argc, VALUE *argv, VALUE self)
 
     rb_iv_set(self, "@tracefunc", block);
 
-    sqlite3_trace(ctx->db, NIL_P(block) ? NULL : tracefunc, (void *)self);
+    sqlite3_trace(ctx->db, NIL_P(block) ? NULL : tracefunc_nogvl, (void *)self);
 
     return self;
+}
+
+struct busy_handler_args {
+    void *context;
+    int count;
+};
+
+static void *
+gvl_call_busy_handler(void *context)
+{
+    struct busy_handler_args *args = context;
+    sqlite3RubyPtr ctx = (sqlite3RubyPtr)args->context;
+
+    VALUE handle = ctx->busy_handler;
+    VALUE result = rb_funcall(handle, rb_intern("call"), 1, INT2NUM(args->count));
+    return (void *)result;
 }
 
 static int
 rb_sqlite3_busy_handler(void *context, int count)
 {
-    sqlite3RubyPtr ctx = (sqlite3RubyPtr)context;
-
-    VALUE handle = ctx->busy_handler;
-    VALUE result = rb_funcall(handle, rb_intern("call"), 1, INT2NUM(count));
+    struct busy_handler_args args = {context, count};
+    VALUE result = (VALUE)rb_thread_call_with_gvl(gvl_call_busy_handler, &args);
 
     if (Qfalse == result) { return 0; }
 
@@ -393,9 +421,20 @@ set_sqlite3_func_result(sqlite3_context *ctx, VALUE result)
     }
 }
 
-static void
-rb_sqlite3_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
+struct rb_sqlite3_func_args {
+    sqlite3_context *ctx;
+    int argc;
+    sqlite3_value **argv;
+};
+
+static void *
+rb_sqlite3_func(void *gvl_context)
 {
+    struct rb_sqlite3_func_args *args = gvl_context;
+    sqlite3_context *ctx = args->ctx;
+    int argc = args->argc;
+    sqlite3_value **argv = args->argv;
+
     VALUE callable = (VALUE)sqlite3_user_data(ctx);
     VALUE params = rb_ary_new2(argc);
     VALUE result;
@@ -411,6 +450,14 @@ rb_sqlite3_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     result = rb_apply(callable, rb_intern("call"), params);
 
     set_sqlite3_func_result(ctx, result);
+    return NULL;
+}
+
+static void
+rb_sqlite3_func_nogvl(sqlite3_context *ctx, int argc, sqlite3_value **argv)
+{
+    struct rb_sqlite3_func_args args = { ctx, argc, argv };
+    rb_thread_call_with_gvl(rb_sqlite3_func, &args);
 }
 
 #ifndef HAVE_RB_PROC_ARITY
@@ -444,7 +491,7 @@ define_function_with_flags(VALUE self, VALUE name, VALUE flags)
                  rb_proc_arity(block),
                  NUM2INT(flags),
                  (void *)block,
-                 rb_sqlite3_func,
+                 rb_sqlite3_func_nogvl,
                  NULL,
                  NULL
              );
@@ -638,10 +685,19 @@ set_extended_result_codes(VALUE self, VALUE enable)
     return self;
 }
 
-int
-rb_comparator_func(void *ctx, int a_len, const void *a, int b_len, const void *b)
-{
+struct comparator_func_args {
     VALUE comparator;
+    int a_len;
+    const char *a;
+    int b_len;
+    const char *b;
+};
+
+static void *
+rb_comparator_func(void *context)
+{
+    struct comparator_func_args *args = context;
+    VALUE comparator = args->comparator;
     VALUE a_str;
     VALUE b_str;
     VALUE comparison;
@@ -649,9 +705,8 @@ rb_comparator_func(void *ctx, int a_len, const void *a, int b_len, const void *b
 
     internal_encoding = rb_default_internal_encoding();
 
-    comparator = (VALUE)ctx;
-    a_str = rb_str_new((const char *)a, a_len);
-    b_str = rb_str_new((const char *)b, b_len);
+    a_str = rb_str_new(args->a, args->a_len);
+    b_str = rb_str_new(args->b, args->b_len);
 
     rb_enc_associate_index(a_str, rb_utf8_encindex());
     rb_enc_associate_index(b_str, rb_utf8_encindex());
@@ -663,7 +718,14 @@ rb_comparator_func(void *ctx, int a_len, const void *a, int b_len, const void *b
 
     comparison = rb_funcall(comparator, rb_intern("compare"), 2, a_str, b_str);
 
-    return NUM2INT(comparison);
+    return (void *)(VALUE)NUM2INT(comparison);
+}
+
+static int
+rb_comparator_func_nogvl(void *ctx, int a_len, const void *a, int b_len, const void *b)
+{
+    struct comparator_func_args args = {(VALUE)ctx, a_len, a, b_len, b};
+    return (int)(VALUE)rb_thread_call_with_gvl(rb_comparator_func, &args);
 }
 
 /* call-seq: db.collation(name, comparator)
@@ -685,7 +747,7 @@ collation(VALUE self, VALUE name, VALUE comparator)
               StringValuePtr(name),
               SQLITE_UTF8,
               (void *)comparator,
-              NIL_P(comparator) ? NULL : rb_comparator_func));
+              NIL_P(comparator) ? NULL : rb_comparator_func_nogvl));
 
     /* Make sure our comparator doesn't get garbage collected. */
     rb_hash_aset(rb_iv_get(self, "@collations"), name, comparator);

--- a/ext/sqlite3/sqlite3_ruby.h
+++ b/ext/sqlite3/sqlite3_ruby.h
@@ -2,6 +2,7 @@
 #define SQLITE3_RUBY
 
 #include <ruby.h>
+#include <ruby/thread.h>
 
 #ifdef UNUSED
 #elif defined(__GNUC__)


### PR DESCRIPTION
Refs #287, but **I don't think this is ready to merge**. As described below the performance impact is very significant. I think this is something the library _should_ do, but it's a penalty that's hard to just eat.

This allows other threads to execute Ruby code (including performing more work sqlite operations if on another DB connection). This should significantly improve multithreaded performance, however as @tenderlove correctly predicted in #287 adds significant overhead to single-threaded performance.

This required wrapping all callbacks which can happen within statement execution with rb_thread_call_with_gvl.

I've written two benchmarks, one which shows why this could be a good idea and one which shows why it's a bad idea. It's unfortunately not clear cut.

### The good

https://gist.github.com/jhawthorn/ae84ee2723ff4930344778cfe40205a2

I made a benchmark based on making sqlite actually do work (a poorly optimized query) before returning, and then having multiple threads perform the same operation. This shows a very significant speed up as we are actually able to run the sqlite operations in parallel.

main

```
$ bundle exec ruby test.rb
single threaded:
0.9432485040742904
multi threaded:
1.1921860249713063
```

This branch:

```
$ bundle exec ruby test.rb
single threaded:
0.927121008047834
multi threaded:
0.17125224182382226
```

### The bad

https://gist.github.com/jhawthorn/492b6a9c5fb6bebe1ebfe985f52495de

When running a completely trivial query in a single thread, this is about 60% slower due to the need to release and re-acquire the GVL on every call to `Statement#step`. I don't think there's an easy way around this as even if our API was a more "bulk" operation (ie "return all rows" rather than "return one row") I believe we'll need the GVL every time we want to allocate a Ruby string and our memory buffer returned from SQLite is only good until our next call to `sqlite3_step`.

```
Comparison:
SELECT * LIMIT 1000 (gvl):     4336.3 i/s
SELECT * LIMIT 1000 (nogvl):     2705.2 i/s - 1.60x  slower
```

I do think this is capturing the absolute worst case as the query is completely trivial and doesn't even make allocations other than the one array per-row.

So that's where we're at. There might be some sort of compromise we could do like making the GVL releasing optional or based on a heuristic. I haven't yet investigated any way to make this faster, but it does seem unlikely we'll find a way to do this without a performance penalty.

### TODO

* [ ] execute_batch2 doesn't yet release the GVL (which probably makes it crashy if any callbacks exist)
* [ ] prepare and some other operations should likely also release the GVL
* [ ] It might be good to provide a UBF to `rb_thread_call_without_gvl`