### PR TITLE
ci: macos images already have sqlite and pkg-config installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           apt-get: libsqlite3-dev
-          brew: sqlite3 pkg-config
           mingw: sqlite3
           vcpkg: sqlite3
       - if: matrix.syslib == 'disable'
@@ -140,7 +139,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           apt-get: libsqlcipher-dev
-          brew: sqlcipher pkg-config
+          brew: sqlcipher
           mingw: sqlcipher
           vcpkg: sqlcipher
       - run: bundle exec rake compile -- --with-sqlcipher
@@ -226,7 +225,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           apt-get: libsqlite3-dev pkg-config
-          brew: sqlite3 pkg-config
           mingw: sqlite3
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
and brew will emit warnings if we ask for them to be installed again, which is super noisy in the github actions UI.