### PR TITLE
ci: stop removing the gem version req from downstream rails build

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -40,7 +40,6 @@ jobs:
           bundle install
           bundle remove sqlite3
           bundle add sqlite3 --path=".."
-          sed -i 's/^gem "sqlite3".*//' activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
       - name: run tests
         run: |
           cd rails/activerecord


### PR DESCRIPTION
When we bumped the version to 2.0 we caught this version pinning problem late. Let's stop removing it so we can be more proactive next time.