### PR TITLE
ci: ensure tcl-dev is installed to build upstream sqlite from source

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -21,10 +21,11 @@ jobs:
       - run: |
           git clone --depth=1 https://github.com/sqlite/sqlite
           git -C sqlite log -n1
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: "3.3"
           bundler-cache: true
+          apt-get: tcl-dev # https://sqlite.org/forum/forumpost/45c4862d37
       - run: bundle exec rake compile -- --with-sqlite-source-dir=${GITHUB_WORKSPACE}/sqlite
       - run: bundle exec rake test
 


### PR DESCRIPTION
This seems to be a new requirement as of around 2024-08-06, see https://sqlite.org/forum/forumpost/45c4862d37 and other forum posts for more context.

Example failure: https://github.com/sparklemotion/sqlite3-ruby/actions/runs/10280777092/job/28462644002