### PR TITLE
Provide the SQL statement context 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sqlite3-ruby Changelog
 
+## next / unreleased
+
+### Improved
+
+- SQL Syntax errors during `Database#prepare` will raise a verbose exception with a multiline message indicating with a "^" exactly where in the statement the error occurred. [#554] @fractaledmind @flavorjones
+
+
 ## 2.1.0 / 2024-09-24
 
 ### Ruby

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -115,3 +115,116 @@ rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg)
     rb_iv_set(exception, "@code", INT2FIX(status));
     rb_exc_raise(exception);
 }
+
+void
+rb_sqlite3_raise_with_sql(sqlite3 *db, int status, const char *sql)
+{
+    VALUE klass = Qnil;
+    VALUE error_message = Qnil;
+    const char* sqlite_error_msg = sqlite3_errmsg(db);
+    int error_offset = sqlite3_error_offset(db);
+
+    /* Consider only lower 8 bits, to work correctly when
+       extended result codes are enabled. */
+    switch (status & 0xff) {
+        case SQLITE_OK:
+            return;
+            break;
+        case SQLITE_ERROR:
+            klass = rb_path2class("SQLite3::SQLException");
+            break;
+        case SQLITE_INTERNAL:
+            klass = rb_path2class("SQLite3::InternalException");
+            break;
+        case SQLITE_PERM:
+            klass = rb_path2class("SQLite3::PermissionException");
+            break;
+        case SQLITE_ABORT:
+            klass = rb_path2class("SQLite3::AbortException");
+            break;
+        case SQLITE_BUSY:
+            klass = rb_path2class("SQLite3::BusyException");
+            break;
+        case SQLITE_LOCKED:
+            klass = rb_path2class("SQLite3::LockedException");
+            break;
+        case SQLITE_NOMEM:
+            klass = rb_path2class("SQLite3::MemoryException");
+            break;
+        case SQLITE_READONLY:
+            klass = rb_path2class("SQLite3::ReadOnlyException");
+            break;
+        case SQLITE_INTERRUPT:
+            klass = rb_path2class("SQLite3::InterruptException");
+            break;
+        case SQLITE_IOERR:
+            klass = rb_path2class("SQLite3::IOException");
+            break;
+        case SQLITE_CORRUPT:
+            klass = rb_path2class("SQLite3::CorruptException");
+            break;
+        case SQLITE_NOTFOUND:
+            klass = rb_path2class("SQLite3::NotFoundException");
+            break;
+        case SQLITE_FULL:
+            klass = rb_path2class("SQLite3::FullException");
+            break;
+        case SQLITE_CANTOPEN:
+            klass = rb_path2class("SQLite3::CantOpenException");
+            break;
+        case SQLITE_PROTOCOL:
+            klass = rb_path2class("SQLite3::ProtocolException");
+            break;
+        case SQLITE_EMPTY:
+            klass = rb_path2class("SQLite3::EmptyException");
+            break;
+        case SQLITE_SCHEMA:
+            klass = rb_path2class("SQLite3::SchemaChangedException");
+            break;
+        case SQLITE_TOOBIG:
+            klass = rb_path2class("SQLite3::TooBigException");
+            break;
+        case SQLITE_CONSTRAINT:
+            klass = rb_path2class("SQLite3::ConstraintException");
+            break;
+        case SQLITE_MISMATCH:
+            klass = rb_path2class("SQLite3::MismatchException");
+            break;
+        case SQLITE_MISUSE:
+            klass = rb_path2class("SQLite3::MisuseException");
+            break;
+        case SQLITE_NOLFS:
+            klass = rb_path2class("SQLite3::UnsupportedException");
+            break;
+        case SQLITE_AUTH:
+            klass = rb_path2class("SQLite3::AuthorizationException");
+            break;
+        case SQLITE_FORMAT:
+            klass = rb_path2class("SQLite3::FormatException");
+            break;
+        case SQLITE_RANGE:
+            klass = rb_path2class("SQLite3::RangeException");
+            break;
+        case SQLITE_NOTADB:
+            klass = rb_path2class("SQLite3::NotADatabaseException");
+            break;
+        default:
+            klass = rb_path2class("SQLite3::Exception");
+    }
+
+    // Create a more detailed error message
+    if (error_offset >= 0 && sql) {
+        char *formatted_error = NULL;
+        asprintf(&formatted_error, "%s\n  %s\n  %*s^--- error here",
+                  sqlite_error_msg, sql, error_offset, "");
+        error_message = rb_str_new2(formatted_error);
+        free(formatted_error);
+    } else {
+        error_message = rb_str_new2(sqlite_error_msg);
+    }
+
+    klass = rb_exc_new3(klass, error_message);
+    rb_iv_set(klass, "@code", INT2FIX(status));
+    rb_iv_set(klass, "@error_offset", INT2FIX(error_offset));
+    rb_exc_raise(klass);
+}

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -1,101 +1,82 @@
 #include <sqlite3_ruby.h>
 
-void
-rb_sqlite3_raise(sqlite3 *db, int status)
+static VALUE
+status2klass(int status)
 {
-    VALUE klass = Qnil;
-
     /* Consider only lower 8 bits, to work correctly when
        extended result codes are enabled. */
     switch (status & 0xff) {
         case SQLITE_OK:
-            return;
-            break;
+            return Qnil;
         case SQLITE_ERROR:
-            klass = rb_path2class("SQLite3::SQLException");
-            break;
+            return rb_path2class("SQLite3::SQLException");
         case SQLITE_INTERNAL:
-            klass = rb_path2class("SQLite3::InternalException");
-            break;
+            return rb_path2class("SQLite3::InternalException");
         case SQLITE_PERM:
-            klass = rb_path2class("SQLite3::PermissionException");
-            break;
+            return rb_path2class("SQLite3::PermissionException");
         case SQLITE_ABORT:
-            klass = rb_path2class("SQLite3::AbortException");
-            break;
+            return rb_path2class("SQLite3::AbortException");
         case SQLITE_BUSY:
-            klass = rb_path2class("SQLite3::BusyException");
-            break;
+            return rb_path2class("SQLite3::BusyException");
         case SQLITE_LOCKED:
-            klass = rb_path2class("SQLite3::LockedException");
-            break;
+            return rb_path2class("SQLite3::LockedException");
         case SQLITE_NOMEM:
-            klass = rb_path2class("SQLite3::MemoryException");
-            break;
+            return rb_path2class("SQLite3::MemoryException");
         case SQLITE_READONLY:
-            klass = rb_path2class("SQLite3::ReadOnlyException");
-            break;
+            return rb_path2class("SQLite3::ReadOnlyException");
         case SQLITE_INTERRUPT:
-            klass = rb_path2class("SQLite3::InterruptException");
-            break;
+            return rb_path2class("SQLite3::InterruptException");
         case SQLITE_IOERR:
-            klass = rb_path2class("SQLite3::IOException");
-            break;
+            return rb_path2class("SQLite3::IOException");
         case SQLITE_CORRUPT:
-            klass = rb_path2class("SQLite3::CorruptException");
-            break;
+            return rb_path2class("SQLite3::CorruptException");
         case SQLITE_NOTFOUND:
-            klass = rb_path2class("SQLite3::NotFoundException");
-            break;
+            return rb_path2class("SQLite3::NotFoundException");
         case SQLITE_FULL:
-            klass = rb_path2class("SQLite3::FullException");
-            break;
+            return rb_path2class("SQLite3::FullException");
         case SQLITE_CANTOPEN:
-            klass = rb_path2class("SQLite3::CantOpenException");
-            break;
+            return rb_path2class("SQLite3::CantOpenException");
         case SQLITE_PROTOCOL:
-            klass = rb_path2class("SQLite3::ProtocolException");
-            break;
+            return rb_path2class("SQLite3::ProtocolException");
         case SQLITE_EMPTY:
-            klass = rb_path2class("SQLite3::EmptyException");
-            break;
+            return rb_path2class("SQLite3::EmptyException");
         case SQLITE_SCHEMA:
-            klass = rb_path2class("SQLite3::SchemaChangedException");
-            break;
+            return rb_path2class("SQLite3::SchemaChangedException");
         case SQLITE_TOOBIG:
-            klass = rb_path2class("SQLite3::TooBigException");
-            break;
+            return rb_path2class("SQLite3::TooBigException");
         case SQLITE_CONSTRAINT:
-            klass = rb_path2class("SQLite3::ConstraintException");
-            break;
+            return rb_path2class("SQLite3::ConstraintException");
         case SQLITE_MISMATCH:
-            klass = rb_path2class("SQLite3::MismatchException");
-            break;
+            return rb_path2class("SQLite3::MismatchException");
         case SQLITE_MISUSE:
-            klass = rb_path2class("SQLite3::MisuseException");
-            break;
+            return rb_path2class("SQLite3::MisuseException");
         case SQLITE_NOLFS:
-            klass = rb_path2class("SQLite3::UnsupportedException");
-            break;
+            return rb_path2class("SQLite3::UnsupportedException");
         case SQLITE_AUTH:
-            klass = rb_path2class("SQLite3::AuthorizationException");
-            break;
+            return rb_path2class("SQLite3::AuthorizationException");
         case SQLITE_FORMAT:
-            klass = rb_path2class("SQLite3::FormatException");
-            break;
+            return rb_path2class("SQLite3::FormatException");
         case SQLITE_RANGE:
-            klass = rb_path2class("SQLite3::RangeException");
-            break;
+            return rb_path2class("SQLite3::RangeException");
         case SQLITE_NOTADB:
-            klass = rb_path2class("SQLite3::NotADatabaseException");
-            break;
+            return rb_path2class("SQLite3::NotADatabaseException");
         default:
-            klass = rb_path2class("SQLite3::Exception");
+            return rb_path2class("SQLite3::Exception");
+    }
+}
+
+void
+rb_sqlite3_raise(sqlite3 *db, int status)
+{
+    VALUE klass = status2klass(status);
+    if (NIL_P(klass)) {
+        return;
     }
 
-    klass = rb_exc_new2(klass, sqlite3_errmsg(db));
-    rb_iv_set(klass, "@code", INT2FIX(status));
-    rb_exc_raise(klass);
+    VALUE exception = rb_exc_new2(klass, sqlite3_errmsg(db));
+    rb_iv_set(exception, "@code", INT2FIX(status));
+
+    rb_exc_raise(exception);
 }
 
 /*
@@ -119,112 +100,29 @@ rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg)
 void
 rb_sqlite3_raise_with_sql(sqlite3 *db, int status, const char *sql)
 {
-    VALUE klass = Qnil;
-    VALUE error_message = Qnil;
-    const char* sqlite_error_msg = sqlite3_errmsg(db);
-    int error_offset = sqlite3_error_offset(db);
-
-    /* Consider only lower 8 bits, to work correctly when
-       extended result codes are enabled. */
-    switch (status & 0xff) {
-        case SQLITE_OK:
-            return;
-            break;
-        case SQLITE_ERROR:
-            klass = rb_path2class("SQLite3::SQLException");
-            break;
-        case SQLITE_INTERNAL:
-            klass = rb_path2class("SQLite3::InternalException");
-            break;
-        case SQLITE_PERM:
-            klass = rb_path2class("SQLite3::PermissionException");
-            break;
-        case SQLITE_ABORT:
-            klass = rb_path2class("SQLite3::AbortException");
-            break;
-        case SQLITE_BUSY:
-            klass = rb_path2class("SQLite3::BusyException");
-            break;
-        case SQLITE_LOCKED:
-            klass = rb_path2class("SQLite3::LockedException");
-            break;
-        case SQLITE_NOMEM:
-            klass = rb_path2class("SQLite3::MemoryException");
-            break;
-        case SQLITE_READONLY:
-            klass = rb_path2class("SQLite3::ReadOnlyException");
-            break;
-        case SQLITE_INTERRUPT:
-            klass = rb_path2class("SQLite3::InterruptException");
-            break;
-        case SQLITE_IOERR:
-            klass = rb_path2class("SQLite3::IOException");
-            break;
-        case SQLITE_CORRUPT:
-            klass = rb_path2class("SQLite3::CorruptException");
-            break;
-        case SQLITE_NOTFOUND:
-            klass = rb_path2class("SQLite3::NotFoundException");
-            break;
-        case SQLITE_FULL:
-            klass = rb_path2class("SQLite3::FullException");
-            break;
-        case SQLITE_CANTOPEN:
-            klass = rb_path2class("SQLite3::CantOpenException");
-            break;
-        case SQLITE_PROTOCOL:
-            klass = rb_path2class("SQLite3::ProtocolException");
-            break;
-        case SQLITE_EMPTY:
-            klass = rb_path2class("SQLite3::EmptyException");
-            break;
-        case SQLITE_SCHEMA:
-            klass = rb_path2class("SQLite3::SchemaChangedException");
-            break;
-        case SQLITE_TOOBIG:
-            klass = rb_path2class("SQLite3::TooBigException");
-            break;
-        case SQLITE_CONSTRAINT:
-            klass = rb_path2class("SQLite3::ConstraintException");
-            break;
-        case SQLITE_MISMATCH:
-            klass = rb_path2class("SQLite3::MismatchException");
-            break;
-        case SQLITE_MISUSE:
-            klass = rb_path2class("SQLite3::MisuseException");
-            break;
-        case SQLITE_NOLFS:
-            klass = rb_path2class("SQLite3::UnsupportedException");
-            break;
-        case SQLITE_AUTH:
-            klass = rb_path2class("SQLite3::AuthorizationException");
-            break;
-        case SQLITE_FORMAT:
-            klass = rb_path2class("SQLite3::FormatException");
-            break;
-        case SQLITE_RANGE:
-            klass = rb_path2class("SQLite3::RangeException");
-            break;
-        case SQLITE_NOTADB:
-            klass = rb_path2class("SQLite3::NotADatabaseException");
-            break;
-        default:
-            klass = rb_path2class("SQLite3::Exception");
+    VALUE klass = status2klass(status);
+    if (NIL_P(klass)) {
+        return;
     }
+
+    VALUE error_message = Qnil;
+    const char *sqlite_error_msg = sqlite3_errmsg(db);
+    int error_offset = sqlite3_error_offset(db);
 
     // Create a more detailed error message
     if (error_offset >= 0 && sql) {
         char *formatted_error = NULL;
         asprintf(&formatted_error, "%s\n  %s\n  %*s^--- error here",
-                  sqlite_error_msg, sql, error_offset, "");
+                 sqlite_error_msg, sql, error_offset, "");
         error_message = rb_str_new2(formatted_error);
         free(formatted_error);
     } else {
         error_message = rb_str_new2(sqlite_error_msg);
     }
 
-    klass = rb_exc_new3(klass, error_message);
-    rb_iv_set(klass, "@code", INT2FIX(status));
-    rb_iv_set(klass, "@error_offset", INT2FIX(error_offset));
-    rb_exc_raise(klass);
+    VALUE exception = rb_exc_new3(klass, error_message);
+    rb_iv_set(exception, "@code", INT2FIX(status));
+    rb_iv_set(exception, "@error_offset", INT2FIX(error_offset));
+
+    rb_exc_raise(exception);
 }

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -85,15 +85,15 @@ rb_sqlite3_raise(sqlite3 *db, int status)
 void
 rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg)
 {
-    VALUE exception;
-
-    if (status == SQLITE_OK) {
+    VALUE klass = status2klass(status);
+    if (NIL_P(klass)) {
         return;
     }
 
-    exception = rb_exc_new2(rb_path2class("SQLite3::Exception"), msg);
-    sqlite3_free((void *)msg);
+    VALUE exception = rb_exc_new2(klass, msg);
     rb_iv_set(exception, "@code", INT2FIX(status));
+    sqlite3_free((void *)msg);
+
     rb_exc_raise(exception);
 }
 

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -112,9 +112,9 @@ rb_sqlite3_raise_with_sql(sqlite3 *db, int status, const char *sql)
     // Create a more detailed error message
     if (error_offset >= 0 && sql) {
         error_message = rb_sprintf(
-            "%s\n  %s\n  %*s^--- error here",
-            sqlite_error_msg, sql, error_offset, ""
-            );
+                            "%s:\n%s\n%*s^\n",
+                            sqlite_error_msg, sql, error_offset, ""
+                        );
     } else {
         error_message = rb_str_new2(sqlite_error_msg);
     }

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -111,11 +111,10 @@ rb_sqlite3_raise_with_sql(sqlite3 *db, int status, const char *sql)
 
     // Create a more detailed error message
     if (error_offset >= 0 && sql) {
-        char *formatted_error = NULL;
-        asprintf(&formatted_error, "%s\n  %s\n  %*s^--- error here",
-                 sqlite_error_msg, sql, error_offset, "");
-        error_message = rb_str_new2(formatted_error);
-        free(formatted_error);
+        error_message = rb_sprintf(
+            "%s\n  %s\n  %*s^--- error here",
+            sqlite_error_msg, sql, error_offset, ""
+            );
     } else {
         error_message = rb_str_new2(sqlite_error_msg);
     }

--- a/ext/sqlite3/exception.h
+++ b/ext/sqlite3/exception.h
@@ -3,8 +3,10 @@
 
 #define CHECK(_db, _status) rb_sqlite3_raise(_db, _status);
 #define CHECK_MSG(_db, _status, _msg) rb_sqlite3_raise_msg(_db, _status, _msg);
+#define CHECK_PREPARE(_db, _status, _sql) rb_sqlite3_raise_with_sql(_db, _status, _sql)
 
 void rb_sqlite3_raise(sqlite3 *db, int status);
 void rb_sqlite3_raise_msg(sqlite3 *db, int status, const char *msg);
+void rb_sqlite3_raise_with_sql(sqlite3 *db, int status, const char *sql);
 
 #endif

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -132,6 +132,7 @@ module Sqlite3
 
         have_func("sqlite3_prepare_v2")
         have_func("sqlite3_db_name", "sqlite3.h") # v3.39.0
+        have_func("sqlite3_error_offset", "sqlite3.h") # v3.38.0
 
         have_type("sqlite3_int64", "sqlite3.h")
         have_type("sqlite3_uint64", "sqlite3.h")

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -78,7 +78,7 @@ prepare(VALUE self, VALUE db, VALUE sql)
                  &tail
              );
 
-    CHECK(db_ctx->db, status);
+    CHECK_PREPARE(db_ctx->db, status, StringValuePtr(sql));
     timespecclear(&db_ctx->stmt_deadline);
 
     return rb_utf8_str_new_cstr(tail);

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -111,11 +111,18 @@ class IntegrationTestCase < SQLite3::TestCase
     exception = assert_raise(SQLite3::SQLException) do
       @db.prepare "select from foo"
     end
-    assert_equal(<<~MSG, exception.message)
-      near "from": syntax error:
-      select from foo
-             ^
-    MSG
+    if exception.sql_offset >= 0 # HAVE_SQLITE_ERROR_OFFSET
+      assert_equal(<<~MSG.chomp, exception.message)
+        near "from": syntax error:
+        select from foo
+               ^
+      MSG
+    else
+      assert_equal(<<~MSG.chomp, exception.message)
+        near "from": syntax error:
+        select from foo
+      MSG
+    end
   end
 
   def test_prepare_exception_shows_error_position_newline1
@@ -125,12 +132,20 @@ class IntegrationTestCase < SQLite3::TestCase
         from foo
       SQL
     end
-    assert_equal(<<~MSG, exception.message)
-      near "from": syntax error:
-      select
-      from foo
-      ^
-    MSG
+    if exception.sql_offset >= 0 # HAVE_SQLITE_ERROR_OFFSET
+      assert_equal(<<~MSG.chomp, exception.message)
+        near "from": syntax error:
+        select
+        from foo
+        ^
+      MSG
+    else
+      assert_equal(<<~MSG.chomp, exception.message)
+        near "from": syntax error:
+        select
+        from foo
+      MSG
+    end
   end
 
   def test_prepare_exception_shows_error_position_newline2
@@ -140,12 +155,20 @@ class IntegrationTestCase < SQLite3::TestCase
         from foo
       SQL
     end
-    assert_equal(<<~MSG, exception.message)
-      no such column: asdf:
-      select asdf
-             ^
-      from foo
-    MSG
+    if exception.sql_offset >= 0 # HAVE_SQLITE_ERROR_OFFSET
+      assert_equal(<<~MSG.chomp, exception.message)
+        no such column: asdf:
+        select asdf
+               ^
+        from foo
+      MSG
+    else
+      assert_equal(<<~MSG.chomp, exception.message)
+        no such column: asdf:
+        select asdf
+        from foo
+      MSG
+    end
   end
 
   def test_prepare_invalid_column

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -102,9 +102,10 @@ class IntegrationTestCase < SQLite3::TestCase
   end
 
   def test_prepare_invalid_syntax
-    assert_raise(SQLite3::SQLException) do
+    exception = assert_raise(SQLite3::SQLException) do
       @db.prepare "select from foo"
     end
+    assert_equal("near \"from\": syntax error\n  select from foo\n         ^--- error here", exception.message)
   end
 
   def test_prepare_invalid_column


### PR DESCRIPTION
for errors that occur when preparing a SQL statement

@flavorjones @tenderlove @byroot 

This is a proof-of-concept PR to explore providing better context for exceptions raised. To begin, I focused on exceptions raised when attempting to prepare a statement. Using the gem over the years, there are other contexts that I found the error messages lacking, but I need to recall them and work on PoCs for each. But I wanted to open this to start the conversation around improving error messages with context.