### PR TITLE
Optimize the statement check for a non-discarded database

### DIFF
--- a/ext/sqlite3/database.h
+++ b/ext/sqlite3/database.h
@@ -3,6 +3,10 @@
 
 #include <sqlite3_ruby.h>
 
+/* bits in the `flags` field */
+#define SQLITE3_RB_DATABASE_READONLY  0x01
+#define SQLITE3_RB_DATABASE_DISCARDED 0x02
+
 struct _sqlite3Ruby {
     sqlite3 *db;
     VALUE busy_handler;

--- a/ext/sqlite3/statement.h
+++ b/ext/sqlite3/statement.h
@@ -5,6 +5,7 @@
 
 struct _sqlite3StmtRuby {
     sqlite3_stmt *st;
+    sqlite3Ruby *db;
     int done_p;
 };
 

--- a/test/test_discarding.rb
+++ b/test/test_discarding.rb
@@ -160,7 +160,7 @@ module SQLite3
         db.send(:discard)
 
         e = assert_raises(SQLite3::Exception) { stmt.execute }
-        assert_match(/cannot use a statement associated with a closed database/, e.message)
+        assert_match(/cannot use a statement associated with a discarded database/, e.message)
 
         assert_nothing_raised { stmt.close }
         assert_predicate(stmt, :closed?)

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -135,6 +135,13 @@ module SQLite3
       end
     end
 
+    def test_closed_db_behavior
+      @db.close
+      result = nil
+      assert_nothing_raised { result = @stmt.execute }
+      refute_nil result
+    end
+
     def test_new_with_remainder
       stmt = SQLite3::Statement.new(@db, "select 'foo';bar")
       assert_equal "bar", stmt.remainder


### PR DESCRIPTION
Closes #564 which pointed out a performance regression from #558.

This also restores the ability (now tested!) to call `Database#close` successfully and defer its cleanup until after `Statement`s are closed, which was the promise of #557 and `sqlite3_close_v2`.


Running the benchmark @tenderlove wrote for #564:

```ruby
#!/usr/bin/env ruby

require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "sqlite3", path: "."
  gem "benchmark-ips"
end

require "sqlite3"
require "benchmark/ips"

file = "/tmp/test.sqlite3"

begin
  File.unlink file
rescue
  nil
end

db = SQLite3::Database.new file
db.execute "create table foo (id int)"

1000.times do |i|
  db.execute "insert into foo (id) values (#{i})"
end

Benchmark.ips do |x|
  x.report("selecting") {
    db.execute("select * from foo").to_a
  }
end

db.close
```

On 480f3e7 after `sqlite3_open_v2` was introduced by #557:

```
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
Warming up --------------------------------------
           selecting   533.000 i/100ms
Calculating -------------------------------------
           selecting      5.306k (± 1.3%) i/s  (188.47 μs/i) -     26.650k in   5.023715s
```

On 81ea485f after fork protection was introduced by #558, performance regressed:

```
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
Warming up --------------------------------------
           selecting   329.000 i/100ms
Calculating -------------------------------------
           selecting      3.261k (± 3.4%) i/s  (306.66 μs/i) -     16.450k in   5.051880s
```

On 56d47a67 in this PR, performance is restored.

```
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
Warming up --------------------------------------
           selecting   548.000 i/100ms
Calculating -------------------------------------
           selecting      5.476k (± 1.7%) i/s  (182.61 μs/i) -     27.400k in   5.004987s
```
