### PR TITLE
Add convenience wrapper for pragma optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sqlite3-ruby Changelog
 
+## next / unreleased
+
+### Added
+
+- `Database#optimize` which wraps the `pragma optimize;` statement. Also added `Constants::Optimize` to allow advanced users to pass a bitmask of options. See https://www.sqlite.org/pragma.html#pragma_optimize. [#572] @alexcwatt @flavorjones
+
+
 ## 2.2.0 / 2024-10-30
 
 ### Added

--- a/lib/sqlite3/constants.rb
+++ b/lib/sqlite3/constants.rb
@@ -170,5 +170,21 @@ module SQLite3
       # This parameter records the number of separate memory allocations currently checked out.
       MALLOC_COUNT = 9
     end
+
+    module Optimize
+      # Debugging mode. Do not actually perform any optimizations but instead return one line of text
+      # for each optimization that would have been done.
+      DEBUG = 0x00001
+
+      # Run ANALYZE on tables that might benefit.
+      ANALYZE_TABLES = 0x00002
+
+      # When running ANALYZE, set a temporary PRAGMA analysis_limit to prevent excess run-time.
+      LIMIT_ANALYZE = 0x00010
+
+      # Check the size of all tables, not just tables that have not been recently used, to see if
+      # any have grown and shrunk significantly and hence might benefit from being re-analyzed.
+      CHECK_ALL_TABLES = 0x10000
+    end
   end
 end

--- a/lib/sqlite3/constants.rb
+++ b/lib/sqlite3/constants.rb
@@ -172,19 +172,27 @@ module SQLite3
     end
 
     module Optimize
-      # Debugging mode. Do not actually perform any optimizations but instead return one line of text
-      # for each optimization that would have been done.
+      # Debugging mode. Do not actually perform any optimizations but instead return one line of
+      # text for each optimization that would have been done. Off by default.
       DEBUG = 0x00001
 
-      # Run ANALYZE on tables that might benefit.
+      # Run ANALYZE on tables that might benefit. On by default.
       ANALYZE_TABLES = 0x00002
 
-      # When running ANALYZE, set a temporary PRAGMA analysis_limit to prevent excess run-time.
+      # When running ANALYZE, set a temporary PRAGMA analysis_limit to prevent excess run-time. On
+      # by default.
       LIMIT_ANALYZE = 0x00010
 
       # Check the size of all tables, not just tables that have not been recently used, to see if
-      # any have grown and shrunk significantly and hence might benefit from being re-analyzed.
+      # any have grown and shrunk significantly and hence might benefit from being re-analyzed. Off
+      # by default.
       CHECK_ALL_TABLES = 0x10000
+
+      # Useful for adding a bit to the default behavior, for example
+      #
+      #     db.optimize(Optimize::DEFAULT | Optimize::CHECK_ALL_TABLES)
+      #
+      DEFAULT = ANALYZE_TABLES | LIMIT_ANALYZE
     end
   end
 end

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -338,6 +338,14 @@ module SQLite3
       set_int_pragma "mmap_size", size
     end
 
+    def optimize(bitmask = nil)
+      if bitmask
+        set_int_pragma "optimize", bitmask
+      else
+        execute("PRAGMA optimize")
+      end
+    end
+
     def page_count
       get_int_pragma "page_count"
     end

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -338,6 +338,10 @@ module SQLite3
       set_int_pragma "mmap_size", size
     end
 
+    # Attempt to optimize the database.
+    #
+    # To customize the optimization options, pass +bitmask+ with a combination
+    # of the Constants::Optimize masks.
     def optimize(bitmask = nil)
       if bitmask
         set_int_pragma "optimize", bitmask

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -342,6 +342,8 @@ module SQLite3
     #
     # To customize the optimization options, pass +bitmask+ with a combination
     # of the Constants::Optimize masks.
+    #
+    # See https://www.sqlite.org/pragma.html#pragma_optimize for more information.
     def optimize(bitmask = nil)
       if bitmask
         set_int_pragma "optimize", bitmask

--- a/test/test_pragmas.rb
+++ b/test/test_pragmas.rb
@@ -2,9 +2,27 @@ require "helper"
 
 module SQLite3
   class TestPragmas < SQLite3::TestCase
+    class DatabaseTracker < SQLite3::Database
+      attr_reader :test_statements
+
+      def initialize(...)
+        @test_statements = []
+        super
+      end
+
+      def execute(sql, bind_vars = [], &block)
+        @test_statements << sql
+        super
+      end
+    end
+
     def setup
       super
-      @db = SQLite3::Database.new(":memory:")
+      @db = DatabaseTracker.new(":memory:")
+    end
+
+    def teardown
+      @db.close
     end
 
     def test_pragma_errors
@@ -31,6 +49,29 @@ module SQLite3
       assert(@db.get_boolean_pragma("read_uncommitted"))
     ensure
       @db.set_boolean_pragma("read_uncommitted", 0)
+    end
+
+    def test_optimize_with_no_args
+      @db.optimize
+
+      assert_equal(["PRAGMA optimize"], @db.test_statements)
+    end
+
+    def test_optimize_with_args
+      @db.optimize(Constants::Optimize::DEFAULT)
+      @db.optimize(Constants::Optimize::ANALYZE_TABLES | Constants::Optimize::LIMIT_ANALYZE)
+      @db.optimize(Constants::Optimize::ANALYZE_TABLES | Constants::Optimize::DEBUG)
+      @db.optimize(Constants::Optimize::DEFAULT | Constants::Optimize::CHECK_ALL_TABLES)
+
+      assert_equal(
+        [
+          "PRAGMA optimize=18",
+          "PRAGMA optimize=18",
+          "PRAGMA optimize=3",
+          "PRAGMA optimize=65554"
+        ],
+        @db.test_statements
+      )
     end
   end
 end


### PR DESCRIPTION
The SQLite docs recommend some cases where `PRAGMA optimize;` should be used: https://www.sqlite.org/pragma.html#pragma_optimize

I have discovered recently a case where this helped a project at work (https://twitter.com/alexcwatt/status/1851094243323912631) and now I'm wondering about how to make this easier to discover and use.

Do we want a way to test that these wrappers translate to the expected `execute` call? I wasn't sure what tests to write for this change.