### PR TITLE
ext: update configure options for upcoming 3.48.x.

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -50,8 +50,9 @@ module Sqlite3
       def configure_packaged_libraries
         minimal_recipe.tap do |recipe|
           recipe.configure_options += [
-            "--enable-shared=no",
-            "--enable-static=yes",
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tcl",
             "--enable-fts5"
           ]
           ENV.to_h.tap do |env|


### PR DESCRIPTION
Note that these changes are backwards-compatible with 3.47.x.

See https://sqlite.org/src/info/32fc9c3f62601684