### PR TITLE
Fix invalid encoding name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - `Database#optimize` which wraps the `pragma optimize;` statement. Also added `Constants::Optimize` to allow advanced users to pass a bitmask of options. See https://www.sqlite.org/pragma.html#pragma_optimize. [#572] @alexcwatt @flavorjones
 
 
+### Fixed
+
+- Fix `Database#encoding=` support for switching the database encoding to `UTF-16BE`, which has been broken since `Database#encoding=` was introduced in v1.3.12 in 2016. [#575] @miyucy
+
+
 ## 2.2.0 / 2024-10-30
 
 ### Added

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -93,7 +93,7 @@ module SQLite3
     LOCKING_MODES = [["normal"], ["exclusive"]]
 
     # The list of valid encodings.
-    ENCODINGS = [["utf-8"], ["utf-16"], ["utf-16le"], ["utf-16be "]]
+    ENCODINGS = [["utf-8"], ["utf-16"], ["utf-16le"], ["utf-16be"]]
 
     # The list of valid WAL checkpoints.
     WAL_CHECKPOINTS = [["passive"], ["full"], ["restart"], ["truncate"]]

--- a/test/test_pragmas.rb
+++ b/test/test_pragmas.rb
@@ -73,5 +73,53 @@ module SQLite3
         @db.test_statements
       )
     end
+
+    def test_encoding_uppercase
+      assert_equal(Encoding::UTF_8, @db.encoding)
+
+      @db.encoding = "UTF-16"
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = "UTF-16LE"
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = "UTF-16BE"
+      assert_equal(Encoding::UTF_16BE, @db.encoding)
+
+      @db.encoding = "UTF-8"
+      assert_equal(Encoding::UTF_8, @db.encoding)
+    end
+
+    def test_encoding_lowercase
+      assert_equal(Encoding::UTF_8, @db.encoding)
+
+      @db.encoding = "utf-16"
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = "utf-16le"
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = "utf-16be"
+      assert_equal(Encoding::UTF_16BE, @db.encoding)
+
+      @db.encoding = "utf-8"
+      assert_equal(Encoding::UTF_8, @db.encoding)
+    end
+
+    def test_encoding_objects
+      assert_equal(Encoding::UTF_8, @db.encoding)
+
+      @db.encoding = Encoding::UTF_16
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = Encoding::UTF_16LE
+      assert_equal(Encoding::UTF_16LE, @db.encoding)
+
+      @db.encoding = Encoding::UTF_16BE
+      assert_equal(Encoding::UTF_16BE, @db.encoding)
+
+      @db.encoding = Encoding::UTF_8
+      assert_equal(Encoding::UTF_8, @db.encoding)
+    end
   end
 end


### PR DESCRIPTION
Found an incorrect setting in the database encoding pragma that could potentially cause character encoding issues.

```ruby
irb(main):012> a = SQLite3::Database.new(":memoery:")
=>
#<SQLite3::Database:0x000000011f6b5330
...
irb(main):013> a.encoding = "utf-16be "
/app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/statement.rb:36:in `prepare': unsupported encoding: UTF-16BE : (SQLite3::SQLException)
PRAGMA encoding='UTF-16BE '
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/statement.rb:36:in `initialize'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:170:in `new'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:170:in `prepare'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:202:in `execute'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/pragmas.rb:65:in `set_enum_pragma'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/pragmas.rb:230:in `encoding='
        from (irb):13:in `<main>'
        from <internal:kernel>:187:in `loop'
        from <internal:prelude>:5:in `irb'
        from (app):16:in `<main>'
irb(main):014> a.encoding = "utf-16be"
/app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/pragmas.rb:63:in `set_enum_pragma': unrecognized encoding "utf-16be" (SQLite3::Exception)
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/pragmas.rb:230:in `encoding='
        from (irb):14:in `<main>'
        from <internal:kernel>:187:in `loop'
        from <internal:prelude>:5:in `irb'
        from (app):16:in `<main>'
irb(main):015> a.execute("pragma encoding='UTF-16BE '")
/app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/statement.rb:36:in `prepare': unsupported encoding: UTF-16BE : (SQLite3::SQLException)
pragma encoding='UTF-16BE '
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/statement.rb:36:in `initialize'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:170:in `new'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:170:in `prepare'
        from /app/vendor/bundle/ruby/3.3.0/gems/sqlite3-2.2.0-arm64-darwin/lib/sqlite3/database.rb:202:in `execute'
        from (irb):15:in `<main>'
        from <internal:kernel>:187:in `loop'
        from <internal:prelude>:5:in `irb'
        from (app):16:in `<main>'
irb(main):016> a.execute("pragma encoding='UTF-16BE'")
=> []
```