### PR TITLE
Enable dbstat table by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - The SQLITE_DBPAGE extension is now enabled by default, which implements an eponymous-only virtual table that provides direct access to the underlying database file by interacting with the pager. See https://www.sqlite.org/dbpage.html for more information. [#578] @flavorjones
+- The DBSTAT extension is now enabled by default, which implements a read-only eponymous virtual table that returns information about the amount of disk space used to store the content of an SQLite database. See https://sqlite.org/dbstat.html for more information. [#580] @pawurb @flavorjones
 - `Database#optimize` which wraps the `pragma optimize;` statement. Also added `Constants::Optimize` to allow advanced users to pass a bitmask of options. See https://www.sqlite.org/pragma.html#pragma_optimize. [#572] @alexcwatt @flavorjones
 - `SQLite3::VERSION_INFO` is a new constant that tracks a bag of metadata about the gem and the sqlite library used. `SQLite3::SQLITE_PACKAGED_LIBRARIES` and `SQLite3::SQLITE_PRECOMPILED_LIBRARIES` are new constants indicating how the gem was built. [#581] @flavorjones
 

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -63,7 +63,8 @@ module Sqlite3
               "-fvisibility=hidden", # see https://github.com/rake-compiler/rake-compiler-dock/issues/87
               "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1",
               "-DSQLITE_USE_URI=1",
-              "-DSQLITE_ENABLE_DBPAGE_VTAB=1"
+              "-DSQLITE_ENABLE_DBPAGE_VTAB=1",
+              "-DSQLITE_ENABLE_DBSTAT_VTAB=1"
             ]
             env["CFLAGS"] = [user_cflags, env["CFLAGS"], more_cflags].flatten.join(" ")
             recipe.configure_options += env.select { |k, v| ENV_ALLOWLIST.include?(k) }

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -727,5 +727,9 @@ module SQLite3
 
       assert_nothing_raised { @db.execute("select count(*) from sqlite_dbpage") }
     end
+
+    def test_dbstat_table_exists
+      assert_nothing_raised { @db.execute("select * from dbstat") }
+    end
   end
 end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -729,6 +729,8 @@ module SQLite3
     end
 
     def test_dbstat_table_exists
+      skip("dbstat not supported") unless SQLite3::SQLITE_PACKAGED_LIBRARIES
+
       assert_nothing_raised { @db.execute("select * from dbstat") }
     end
   end


### PR DESCRIPTION
Hi. Similar to https://github.com/TryGhost/node-sqlite3/issues/1279 . This PR enables `dbstat` table, that contains useful info like size of tables, indexes, etc. useful for debugging. 