### PR TITLE
Track metadata in VERSION_INFO

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -14,6 +14,9 @@ exclude:
 - "bin"
 - "rakelib"
 - "ext/sqlite3/extconf.rb"
+- "vendor"
+- "ports"
+- "tmp"
 hyperlink_all: false
 line_numbers: false
 locale: 

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -95,6 +95,9 @@ module Sqlite3
           end
 
           ldflags.each { |ldflag| append_ldflags(ldflag) }
+
+          append_cppflags("-DUSING_PACKAGED_LIBRARIES")
+          append_cppflags("-DUSING_PRECOMPILED_LIBRARIES") if cross_build?
         end
       end
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -201,8 +201,13 @@ Init_sqlite3_native(void)
     rb_define_singleton_method(mSqlite3, "libversion", libversion, 0);
     rb_define_singleton_method(mSqlite3, "threadsafe", threadsafe_p, 0);
     rb_define_singleton_method(mSqlite3, "status", rb_sqlite3_status, -1);
-    rb_define_const(mSqlite3, "SQLITE_VERSION", rb_str_new2(SQLITE_VERSION));
-    rb_define_const(mSqlite3, "SQLITE_VERSION_NUMBER", INT2FIX(SQLITE_VERSION_NUMBER));
-    rb_define_const(mSqlite3, "SQLITE_LOADED_VERSION", rb_str_new2(sqlite3_libversion()));
 
+    /* (String) The version of the sqlite3 library compiled with (e.g., "3.46.1") */
+    rb_define_const(mSqlite3, "SQLITE_VERSION", rb_str_new2(SQLITE_VERSION));
+
+    /* (Integer) The version of the sqlite3 library compiled with (e.g., 346001) */
+    rb_define_const(mSqlite3, "SQLITE_VERSION_NUMBER", INT2FIX(SQLITE_VERSION_NUMBER));
+
+    /* (String) The version of the sqlite3 library loaded at runtime (e.g., "3.46.1") */
+    rb_define_const(mSqlite3, "SQLITE_LOADED_VERSION", rb_str_new2(sqlite3_libversion()));
 }

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -210,4 +210,16 @@ Init_sqlite3_native(void)
 
     /* (String) The version of the sqlite3 library loaded at runtime (e.g., "3.46.1") */
     rb_define_const(mSqlite3, "SQLITE_LOADED_VERSION", rb_str_new2(sqlite3_libversion()));
+
+#ifdef USING_PACKAGED_LIBRARIES
+    rb_define_const(mSqlite3, "SQLITE_PACKAGED_LIBRARIES", Qtrue);
+#else
+    rb_define_const(mSqlite3, "SQLITE_PACKAGED_LIBRARIES", Qfalse);
+#endif
+
+#ifdef USING_PRECOMPILED_LIBRARIES
+    rb_define_const(mSqlite3, "SQLITE_PRECOMPILED_LIBRARIES", Qtrue);
+#else
+    rb_define_const(mSqlite3, "SQLITE_PRECOMPILED_LIBRARIES", Qfalse);
+#endif
 }

--- a/lib/sqlite3.rb
+++ b/lib/sqlite3.rb
@@ -15,3 +15,5 @@ module SQLite3
     threadsafe > 0
   end
 end
+
+require "sqlite3/version_info"

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -1,3 +1,4 @@
 module SQLite3
+  # (String) the version of the sqlite3 gem, e.g. "2.1.1"
   VERSION = "2.2.0"
 end

--- a/lib/sqlite3/version_info.rb
+++ b/lib/sqlite3/version_info.rb
@@ -8,6 +8,8 @@ module SQLite3
     sqlite: {
       compiled: SQLite3::SQLITE_VERSION,
       loaded: SQLite3::SQLITE_LOADED_VERSION,
+      packaged: SQLite3::SQLITE_PACKAGED_LIBRARIES,
+      precompiled: SQLite3::SQLITE_PRECOMPILED_LIBRARIES,
       sqlcipher: SQLite3.sqlcipher?,
       threadsafe: SQLite3.threadsafe?
     }

--- a/lib/sqlite3/version_info.rb
+++ b/lib/sqlite3/version_info.rb
@@ -1,0 +1,15 @@
+module SQLite3
+  # a hash of descriptive metadata about the current version of the sqlite3 gem
+  VERSION_INFO = {
+    ruby: RUBY_DESCRIPTION,
+    gem: {
+      version: SQLite3::VERSION
+    },
+    sqlite: {
+      compiled: SQLite3::SQLITE_VERSION,
+      loaded: SQLite3::SQLITE_LOADED_VERSION,
+      sqlcipher: SQLite3.sqlcipher?,
+      threadsafe: SQLite3.threadsafe?
+    }
+  }
+end

--- a/rakelib/check-manifest.rake
+++ b/rakelib/check-manifest.rake
@@ -10,6 +10,7 @@ task :check_manifest do
     .git
     .github
     .ruby-lsp
+    adr
     bin
     doc
     gems

--- a/sqlite3.gemspec
+++ b/sqlite3.gemspec
@@ -67,7 +67,8 @@ Gem::Specification.new do |s|
     "lib/sqlite3/resultset.rb",
     "lib/sqlite3/statement.rb",
     "lib/sqlite3/value.rb",
-    "lib/sqlite3/version.rb"
+    "lib/sqlite3/version.rb",
+    "lib/sqlite3/version_info.rb"
   ]
 
   s.extra_rdoc_files = [

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,8 @@
 require "sqlite3"
 require "minitest/autorun"
+require "yaml"
 
-puts "info: ruby version: #{RUBY_DESCRIPTION}"
-puts "info: gem version: #{SQLite3::VERSION}"
-puts "info: sqlite version: #{SQLite3::SQLITE_VERSION}/#{SQLite3::SQLITE_LOADED_VERSION}"
-puts "info: sqlcipher?: #{SQLite3.sqlcipher?}"
-puts "info: threadsafe?: #{SQLite3.threadsafe?}"
+puts SQLite3::VERSION_INFO.to_yaml
 
 module SQLite3
   class TestCase < Minitest::Test


### PR DESCRIPTION
New constants track additional metadata:
- `SQLite3::SQLITE_PACKAGED_LIBRARIES` (boolean) true if the gem is using the packaged libsqlite3, false if system libraries
- `SQLite3::SQLITE_PRECOMPILED_LIBRARIES` (boolean) true if the gem is using precompiled packaged libsqlite3

New constant tracking a potpourri of metadata: `SQLite3::VERSION_INFO`

This should unblock #578 