### PR TITLE
doc: remove mention of the pkg-config gem from extconf warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fix `Database#encoding=` support for switching the database encoding to `UTF-16BE`, which has been broken since `Database#encoding=` was introduced in v1.3.12 in 2016. [#575] @miyucy
+- Omit mention of the `pkg-config` gem when failing to build from source, since it is not used. [#358] @flavorjones
 
 
 ## 2.2.0 / 2024-10-30

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -175,7 +175,7 @@ module Sqlite3
       end
 
       def abort_pkg_config(id)
-        abort("\nCould not configure the build properly (#{id}). Please install either the `pkg-config` utility or the `pkg-config` rubygem.\n\n")
+        abort("\nCould not configure the build properly (#{id}). Please install the `pkg-config` utility.\n\n")
       end
 
       def cross_build?


### PR DESCRIPTION
Closes #358