### PR TITLE
feat: easier and more flexible loading of sqlite extensions

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -17,6 +17,7 @@ exclude:
 - "vendor"
 - "ports"
 - "tmp"
+- "pkg"
 hyperlink_all: false
 line_numbers: false
 locale: 

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -771,14 +771,8 @@ collation(VALUE self, VALUE name, VALUE comparator)
 }
 
 #ifdef HAVE_SQLITE3_LOAD_EXTENSION
-/* call-seq: db.load_extension(file)
- *
- * Loads an SQLite extension library from the named file. Extension
- * loading must be enabled using db.enable_load_extension(true) prior
- * to calling this API.
- */
 static VALUE
-load_extension(VALUE self, VALUE file)
+load_extension_internal(VALUE self, VALUE file)
 {
     sqlite3RubyPtr ctx;
     int status;
@@ -997,7 +991,7 @@ init_sqlite3_database(void)
     rb_define_private_method(cSqlite3Database, "db_filename", db_filename, 1);
 
 #ifdef HAVE_SQLITE3_LOAD_EXTENSION
-    rb_define_method(cSqlite3Database, "load_extension", load_extension, 1);
+    rb_define_private_method(cSqlite3Database, "load_extension_internal", load_extension_internal, 1);
 #endif
 
 #ifdef HAVE_SQLITE3_ENABLE_LOAD_EXTENSION

--- a/lib/sqlite3/version.rb
+++ b/lib/sqlite3/version.rb
@@ -1,4 +1,4 @@
 module SQLite3
   # (String) the version of the sqlite3 gem, e.g. "2.1.1"
-  VERSION = "2.3.1"
+  VERSION = "2.4.0.dev"
 end


### PR DESCRIPTION
Using [sqlite extensions](https://www.sqlite.org/loadext.html) in a Rails app is currently a bit tricky.

Assuming you can figure out how to compile it, where do you put the extension on disk? If it's provided by a gem, how do you get a reliable path that works robustly across environments and upgrades?

Do you monkeypatch the sqlite3 adapter to call `#load_extension`, or do you explicitly inject the extension yourself before any query that needs it?

Using sqlite extensions shouldn't be this hard.

The goal of this PR is to enable injection of sqlite extensions by specifying the name of a Ruby constant in a Rails database config:

```yaml
development:
  adapter: sqlite3
  database: storage/development.sqlite3
  extensions:
    - SQLean::Crypto
```


### 0. Establishing a packaging convention

Over this past weekend, I packaged up the https://github.com/nalgeon/sqlean/ extensions as a Ruby gem: https://github.com/flavorjones/sqlean-ruby

The gem offers a set of modules that simply return the filesystem path of the extension files. Each module implements this interface, which I'll call `_ExtensionSpecifier`:

    interface _ExtensionSpecifier
      def to_path: () → String
    end

So, for example, on my machine:

```ruby
SQLean::Crypto.to_path
=> "/home/flavorjones/.../ruby/3.3.6/lib/ruby/gems/3.3.0/gems/sqlean-0.2.0-x86_64-linux-gnu/lib/sqlean/dist/x86_64-linux-gnu/crypto"
```

which means I can load the extension like so:

```ruby
db = SQLite3::Database.new(":memory:")
db.enable_load_extension(true)
db.load_extension(SQLean::Crypto.to_path)
```

I think this is a reasonable self-describing pattern for an extensions gem to offer. Assuming a future world where other people package up their extensions like this ...


### 1. `Database#load_extension` contract

`Database#load_extension` now supports `_ExtensionSpecifier` in addition to filesystem paths.

When passed an object that responds to `#to_path`, that method's return value is used as the filesystem path for the extension, allowing a terser calling convention than above:

```ruby
db.load_extension(SQLean::Crypto)
```


### 2. `Database#new` supports `extensions:`

`Database#new` supports an `extensions:` keyword argument which accepts:

- `String` filesystem path
- `_ExtensionSpecifier` object
- the **name of a constant** that is an `_ExtensionSpecifier`

This last feature, the name of a constant, looks like this when called directly:

```ruby
Database.new(":memory:", extensions: ["SQLean::Crypto"])
```

but more interestingly is what allows injection of extensions in a Rails database config.

### 3. The result

In a sample Rails app I've got that uses the `sqlean` gem:

```yaml
development:
  primary:
    adapter: sqlite3
    extensions:
      - SQLean::Crypto
```

And it just works:

```
$ bin/rails c
>> User.connection.execute("select hex(crypto_blake3('abc'))")
   (3.9ms)  select hex(crypto_blake3('abc'))
=> [{"hex(crypto_blake3('abc'))"=>"6437B3AC38465133FFB63B75273A8DB548C558465D79DB03FD359C6CD5BD9D85"}]
```
