### PR TITLE
ci: remove gem-update-system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,6 @@ jobs:
             ${{ matrix.docker_platform}} ruby:${{ matrix.ruby }}${{ matrix.docker_tag }} \
             sh -c "
               ${{ matrix.bootstrap }}
-              gem update --system &&
               ./bin/test-gem-install ./gems
             "
 


### PR DESCRIPTION
which may not be necessary anymore? It's slow on the aarch64-linux systems so let's try to remove it.