### PR TITLE
doc: refine README by add more thread-safe example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ ts = 10.times.map {
 p ts.map(&:value)
 ```
 
+However, beware `SQLite3::Database#transaction` is not thread-safe. You should
+provide some mechanisms such as locking or connection pooling for thread safety.
+For example:
+
+```ruby
+require 'sqlite3'
+
+db = SQLite3::Database.new('db.sqlite')
+stmt_lock = Mutex.new
+
+2.times.map do
+  Thread.new do
+    stmt_lock.synchronize do
+      db.transaction { sleep 1 }
+    end
+  end
+end.each(&:join)
+```
+
 Other instances can be shared among threads, but they require that you provide
 your own locking for thread safety.  For example, `SQLite3::Statement` objects
 (prepared statements) are mutable, so applications must take care to add


### PR DESCRIPTION
The following statement isn't true, because `SQLite3::Database#transaction` isn't thread-safe:

> When `SQLite3.threadsafe?` returns `true`, it is safe to share only `SQLite3::Database` instances among threads without providing your own locking mechanism.

Here is an example to prove `SQLite3::Database#transaction` isn't thread-safe:

```ruby
require 'sqlite3'

db = SQLite3::Database.new('db.sqlite')
2.times.map do
  Thread.new do
    db.transaction { sleep 1 }
  end
end.each(&:join)
```

```
λ docker run --rm -i ruby:3.4-alpine sh -c 'gem install sqlite3 && exec ruby' < sqlite3.rb
Successfully installed sqlite3-2.5.0-x86_64-linux-musl
1 gem installed
#<Thread:0x00007ffaa53d2dc0 -:5 run> terminated with exception (report_on_exception is true):
/usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:43:in 'SQLite3::Statement#step': cannot start a transaction within a transaction (SQLite3::SQLException)
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:43:in 'SQLite3::ResultSet#next'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:49:in 'SQLite3::ResultSet#each'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:257:in 'Enumerable#to_a'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:257:in 'block in SQLite3::Database#execute'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:220:in 'SQLite3::Database#prepare'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:248:in 'SQLite3::Database#execute'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:647:in 'SQLite3::Database#transaction'
        from -:6:in 'block (2 levels) in <main>'
/usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:43:in 'SQLite3::Statement#step': cannot start a transaction within a transaction (SQLite3::SQLException)
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:43:in 'SQLite3::ResultSet#next'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/resultset.rb:49:in 'SQLite3::ResultSet#each'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:257:in 'Enumerable#to_a'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:257:in 'block in SQLite3::Database#execute'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:220:in 'SQLite3::Database#prepare'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:248:in 'SQLite3::Database#execute'
        from /usr/local/bundle/gems/sqlite3-2.5.0-x86_64-linux-musl/lib/sqlite3/database.rb:647:in 'SQLite3::Database#transaction'
        from -:6:in 'block (2 levels) in <main>'
```