### PR TITLE
dep: update vendored sqlite to 3.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Vendored sqlite is updated to [v3.49.0](https://sqlite.org/releaselog/3_49.0.html) (from v3.47.2). #605 @flavorjones
+- Vendored sqlite is updated to [v3.49.1](https://sqlite.org/releaselog/3_49_1.html) (from v3.47.2). #605 @flavorjones
 - Updated to rake-compiler-dock v1.9.1. #610 @flavorjones
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Vendored sqlite is updated to [v3.48.0](https://sqlite.org/releaselog/3_48.0.html) #605 @flavorjones
+- Vendored sqlite is updated to [v3.49.0](https://sqlite.org/releaselog/3_49.0.html) (from v3.47.2). #605 @flavorjones
 - Updated to rake-compiler-dock v1.9.1. #610 @flavorjones
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Dependencies
 
-- Updated to rake-compiler-dock v1.9.1.
+- Vendored sqlite is updated to [v3.48.0](https://sqlite.org/releaselog/3_48.0.html) #605 @flavorjones
+- Updated to rake-compiler-dock v1.9.1. #610 @flavorjones
 
 
 ## 2.5.0 / 2024-12-25

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 52cd4a2304b627abbabe1a438ba853d0f6edb8e2774fcb5773c7af11077afe94
+  # df4fe162b8b73e8a9ba9f362280f0758dbf67e77de59d3d65dcbf8f6abc25706
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3480000.tar.gz
-  # 279e3dd8fc8fea6d56acb79b380440b57f8e0c02b371e3b195c993b51c2b5b0c  ports/archives/sqlite-autoconf-3480000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3490000.tar.gz
+  # df4fe162b8b73e8a9ba9f362280f0758dbf67e77de59d3d65dcbf8f6abc25706  ports/archives/sqlite-autoconf-3490000.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3480000.tar.gz
-  # ac992f7fca3989de7ed1fe99c16363f848794c8c32a158dafd4eb927a2e02fd5  ports/archives/sqlite-autoconf-3480000.tar.gz
-  version: "3.48.0"
+  # $ sha256sum ports/archives/sqlite-autoconf-3490000.tar.gz
+  # 4d8bfa0b55e36951f6e5a9fb8c99f3b58990ab785c57b4f84f37d163a0672759  ports/archives/sqlite-autoconf-3490000.tar.gz
+  version: "3.49.0"
   files:
-    - url: "https://sqlite.org/2025/sqlite-autoconf-3480000.tar.gz"
-      sha256: "ac992f7fca3989de7ed1fe99c16363f848794c8c32a158dafd4eb927a2e02fd5"
+    - url: "https://sqlite.org/2025/sqlite-autoconf-3490000.tar.gz"
+      sha256: "4d8bfa0b55e36951f6e5a9fb8c99f3b58990ab785c57b4f84f37d163a0672759"

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,12 +2,12 @@ sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
   # 52cd4a2304b627abbabe1a438ba853d0f6edb8e2774fcb5773c7af11077afe94
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3470200.tar.gz
-  # 52cd4a2304b627abbabe1a438ba853d0f6edb8e2774fcb5773c7af11077afe94  ports/archives/sqlite-autoconf-3470200.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3480000.tar.gz
+  # 279e3dd8fc8fea6d56acb79b380440b57f8e0c02b371e3b195c993b51c2b5b0c  ports/archives/sqlite-autoconf-3480000.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3470200.tar.gz
-  # f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b  ports/archives/sqlite-autoconf-3470200.tar.gz
-  version: "3.47.2"
+  # $ sha256sum ports/archives/sqlite-autoconf-3480000.tar.gz
+  # ac992f7fca3989de7ed1fe99c16363f848794c8c32a158dafd4eb927a2e02fd5  ports/archives/sqlite-autoconf-3480000.tar.gz
+  version: "3.48.0"
   files:
-    - url: "https://sqlite.org/2024/sqlite-autoconf-3470200.tar.gz"
-      sha256: "f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b"
+    - url: "https://sqlite.org/2025/sqlite-autoconf-3480000.tar.gz"
+      sha256: "ac992f7fca3989de7ed1fe99c16363f848794c8c32a158dafd4eb927a2e02fd5"

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # df4fe162b8b73e8a9ba9f362280f0758dbf67e77de59d3d65dcbf8f6abc25706
+  # 6cc831c9f588b637e5bd48d9fbf28e58737e08daf825c81085fb8e0a0b8ad14c
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3490000.tar.gz
-  # df4fe162b8b73e8a9ba9f362280f0758dbf67e77de59d3d65dcbf8f6abc25706  ports/archives/sqlite-autoconf-3490000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3490100.tar.gz
+  # 6cc831c9f588b637e5bd48d9fbf28e58737e08daf825c81085fb8e0a0b8ad14c  ports/archives/sqlite-autoconf-3490100.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3490000.tar.gz
-  # 4d8bfa0b55e36951f6e5a9fb8c99f3b58990ab785c57b4f84f37d163a0672759  ports/archives/sqlite-autoconf-3490000.tar.gz
-  version: "3.49.0"
+  # $ sha256sum ports/archives/sqlite-autoconf-3490100.tar.gz
+  # 106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254  ports/archives/sqlite-autoconf-3490100.tar.gz
+  version: "3.49.1"
   files:
-    - url: "https://sqlite.org/2025/sqlite-autoconf-3490000.tar.gz"
-      sha256: "4d8bfa0b55e36951f6e5a9fb8c99f3b58990ab785c57b4f84f37d163a0672759"
+    - url: "https://sqlite.org/2025/sqlite-autoconf-3490100.tar.gz"
+      sha256: "106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254"

--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -789,7 +789,7 @@ load_extension_internal(VALUE self, VALUE file)
 }
 #endif
 
-#ifdef HAVE_SQLITE3_ENABLE_LOAD_EXTENSION
+#if defined(HAVE_SQLITE3_ENABLE_LOAD_EXTENSION) && defined(HAVE_SQLITE3_LOAD_EXTENSION)
 /* call-seq: db.enable_load_extension(onoff)
  *
  * Enable or disable extension loading.
@@ -992,11 +992,11 @@ init_sqlite3_database(void)
 
 #ifdef HAVE_SQLITE3_LOAD_EXTENSION
     rb_define_private_method(cSqlite3Database, "load_extension_internal", load_extension_internal, 1);
-#endif
-
 #ifdef HAVE_SQLITE3_ENABLE_LOAD_EXTENSION
     rb_define_method(cSqlite3Database, "enable_load_extension", enable_load_extension, 1);
 #endif
+#endif
+
 
     rb_sqlite3_aggregator_init();
 }

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -52,7 +52,6 @@ module Sqlite3
           recipe.configure_options += [
             "--disable-shared",
             "--enable-static",
-            "--disable-tcl",
             "--enable-fts5"
           ]
           ENV.to_h.tap do |env|

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -667,8 +667,17 @@ module SQLite3
       assert_match(/no such column: "?nope"?/, error.message)
     end
 
+    def test_load_extension_is_defined_on_expected_platforms
+      if ::RUBY_PLATFORM =~ /mingw|mswin/ && SQLite3::SQLITE_PACKAGED_LIBRARIES
+        skip("as of sqlite 3.48.0, the autoconf amalgamation does not reliably find dlopen" \
+             "on windows when building sqlite from source")
+      end
+      assert_respond_to(db, :load_extension)
+      assert_respond_to(db, :enable_load_extension)
+    end
+
     def test_load_extension_error_with_nonexistent_path
-      skip("extensions are not enabled") unless db.respond_to?(:load_extension)
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
       db.enable_load_extension(true)
 
       assert_raises(SQLite3::Exception) { db.load_extension("/nonexistent/path") }
@@ -676,7 +685,7 @@ module SQLite3
     end
 
     def test_load_extension_error_with_invalid_argument
-      skip("extensions are not enabled") unless db.respond_to?(:load_extension)
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
       db.enable_load_extension(true)
 
       assert_raises(TypeError) { db.load_extension(1) }
@@ -686,6 +695,8 @@ module SQLite3
     end
 
     def test_load_extension_with_an_extension_descriptor
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
+
       mock_database_load_extension_internal(db)
 
       db.load_extension(Pathname.new("/path/to/ext2"))
@@ -698,7 +709,10 @@ module SQLite3
     end
 
     def test_initialize_extensions_with_extensions_calls_enable_load_extension
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
+
       mock_database_load_extension_internal(db)
+
       class << db
         attr_accessor :enable_load_extension_called
         attr_reader :enable_load_extension_arg
@@ -734,6 +748,8 @@ module SQLite3
     end
 
     def test_initialize_extensions_object_is_an_extension_specifier
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
+
       mock_database_load_extension_internal(db)
 
       db.initialize_extensions([Pathname.new("/path/to/extension")])
@@ -746,6 +762,8 @@ module SQLite3
     end
 
     def test_initialize_extensions_object_not_an_extension_specifier
+      skip("extensions are not enabled") unless db.respond_to?(:enable_load_extension)
+
       mock_database_load_extension_internal(db)
 
       db.initialize_extensions(["/path/to/extension"])


### PR DESCRIPTION
This skips 3.48.0 and 3.49.0 because the autoconf package is not building properly across all platforms, as noted in comments below.

- https://sqlite.org/releaselog/3_48_0.html
- https://sqlite.org/releaselog/3_49_0.html
- https://sqlite.org/releaselog/3_49_1.html

Note that this PR also updates tests to not expect to be able to load extensions when running on Windows systems using the packaged library. The autoconf amalgamation is not picking up dlopen during configuration on Windows systems and I have been unable to figure out why.
