### PR TITLE
dep: move style and docs deps into a separate group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
     branches:
       - '*'
 
+env:
+  BUNDLE_WITHOUT: "development"
+
 jobs:
   ruby_versions:
     outputs:
@@ -31,6 +34,8 @@ jobs:
   #
   rubocop:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: "" # we need rubocop, obviously
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -101,7 +106,7 @@ jobs:
     steps:
       - run: |
           dnf group install -y "C Development Tools and Libraries"
-          dnf install -y ruby ruby-devel libyaml-devel
+          dnf install -y ruby ruby-devel
       - uses: actions/checkout@v4
       - run: bundle install
       - run: bundle exec rake compile -- --disable-system-libraries
@@ -118,6 +123,7 @@ jobs:
           usesh: true
           copyback: false
           prepare: pkg install -y ruby devel/ruby-gems pkgconf
+          envs: BUNDLE_WITHOUT
           run: |
             gem install bundler
             bundle install --local || bundle install
@@ -294,10 +300,10 @@ jobs:
         ruby: ${{ fromJSON(needs.ruby_versions.outputs.image_tag) }}
         include:
           # declare docker image for each platform
-          - { platform: aarch64-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base yaml-dev &&" }
-          - { platform: arm-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base yaml-dev &&" }
-          - { platform: x86-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base yaml-dev &&" }
-          - { platform: x86_64-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base yaml-dev &&" }
+          - { platform: aarch64-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: arm-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: x86-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: x86_64-linux-musl, docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
           # declare docker platform for each platform
           - { platform: aarch64-linux-gnu, docker_platform: "--platform=linux/arm64" }
           - { platform: aarch64-linux-musl, docker_platform: "--platform=linux/arm64" }
@@ -371,5 +377,5 @@ jobs:
         with:
           name: cruby-x86_64-linux-musl-gem
           path: gems
-      - run: apk add build-base yaml-dev
+      - run: apk add build-base
       - run: ./bin/test-gem-install ./gems

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler: latest
           bundler-cache: true
           apt-get: sqlite3 # active record test suite uses the sqlite3 cli
@@ -37,7 +37,7 @@ jobs:
         run: |
           git clone --depth 1 --branch main https://github.com/rails/rails
           cd rails
-          bundle install
+          bundle install --prefer-local
           bundle remove sqlite3
           bundle add sqlite3 --path=".."
       - name: run tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,16 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development do
+group :test do
   gem "minitest", "5.25.4"
-
-  gem "rake-compiler", "1.2.9"
-  gem "rake-compiler-dock", "1.9.1"
 
   gem "ruby_memcheck", "3.0.1" if Gem::Platform.local.os == "linux"
 
+  gem "rake-compiler", "1.2.9"
+  gem "rake-compiler-dock", "1.9.1"
+end
+
+group :development do
   gem "rdoc", "6.11.0"
 
   gem "rubocop", "1.59.0", require: false

--- a/bin/test-gem-build
+++ b/bin/test-gem-build
@@ -16,6 +16,7 @@ test -e /etc/os-release && cat /etc/os-release
 
 set -x
 
+bundle config set without development
 bundle install --local || bundle install
 bundle exec rake set-version-to-timestamp
 

--- a/bin/test-gem-install
+++ b/bin/test-gem-install
@@ -2,7 +2,7 @@
 #
 #  run as part of CI
 #
-if [[ $# -lt 1 ]] ; then
+if [ $# -lt 1 ] ; then
   echo "usage: $(basename $0) <gems_dir> [install_flags]"
   exit 1
 fi

--- a/bin/test-gem-install
+++ b/bin/test-gem-install
@@ -24,6 +24,7 @@ cd $GEMS_DIR
 
 cd ..
 
+bundle config set without development
 bundle install --local || bundle install
 
 rm -rf lib ext # ensure we don't use the local files

--- a/rakelib/format.rake
+++ b/rakelib/format.rake
@@ -1,70 +1,75 @@
 require "rake/clean"
-require "rubocop/rake_task"
 
-module AstyleHelper
-  class << self
-    def run(files)
-      assert
-      command = ["astyle", args, files].flatten.shelljoin
-      system(command)
-    end
+begin
+  require "rubocop/rake_task"
 
-    def assert
-      require "mkmf"
-      find_executable0("astyle") || raise("Could not find command 'astyle'")
-    end
+  module AstyleHelper
+    class << self
+      def run(files)
+        assert
+        command = ["astyle", args, files].flatten.shelljoin
+        system(command)
+      end
 
-    def args
-      [
-        # indentation
-        "--indent=spaces=4",
-        "--indent-switches",
+      def assert
+        require "mkmf"
+        find_executable0("astyle") || raise("Could not find command 'astyle'")
+      end
 
-        # brackets
-        "--style=1tbs",
-        "--keep-one-line-blocks",
+      def args
+        [
+          # indentation
+          "--indent=spaces=4",
+          "--indent-switches",
 
-        # where do we want spaces
-        "--unpad-paren",
-        "--pad-header",
-        "--pad-oper",
-        "--pad-comma",
+          # brackets
+          "--style=1tbs",
+          "--keep-one-line-blocks",
 
-        # "void *pointer" and not "void* pointer"
-        "--align-pointer=name",
+          # where do we want spaces
+          "--unpad-paren",
+          "--pad-header",
+          "--pad-oper",
+          "--pad-comma",
 
-        # function definitions and declarations
-        "--break-return-type",
-        "--attach-return-type-decl",
+          # "void *pointer" and not "void* pointer"
+          "--align-pointer=name",
 
-        # gotta set a limit somewhere
-        "--max-code-length=100",
+          # function definitions and declarations
+          "--break-return-type",
+          "--attach-return-type-decl",
 
-        # be quiet about files that haven't changed
-        "--formatted",
-        "--verbose"
-      ]
-    end
+          # gotta set a limit somewhere
+          "--max-code-length=100",
 
-    def c_files
-      SQLITE3_SPEC.files.grep(%r{ext/sqlite3/.*\.[ch]\Z})
+          # be quiet about files that haven't changed
+          "--formatted",
+          "--verbose"
+        ]
+      end
+
+      def c_files
+        SQLITE3_SPEC.files.grep(%r{ext/sqlite3/.*\.[ch]\Z})
+      end
     end
   end
-end
 
-namespace "format" do
-  desc "Format C code"
-  task "c" do
-    puts "Running astyle on C files ..."
-    AstyleHelper.run(AstyleHelper.c_files)
+  namespace "format" do
+    desc "Format C code"
+    task "c" do
+      puts "Running astyle on C files ..."
+      AstyleHelper.run(AstyleHelper.c_files)
+    end
+
+    CLEAN.add(AstyleHelper.c_files.map { |f| "#{f}.orig" })
+
+    desc "Format Ruby code"
+    task "ruby" => "rubocop:autocorrect"
   end
 
-  CLEAN.add(AstyleHelper.c_files.map { |f| "#{f}.orig" })
+  RuboCop::RakeTask.new
 
-  desc "Format Ruby code"
-  task "ruby" => "rubocop:autocorrect"
+  task "format" => ["format:c", "format:ruby"]
+rescue LoadError => e
+  puts "NOTE: Rubocop is not available in this environment: #{e.message}"
 end
-
-RuboCop::RakeTask.new
-
-task "format" => ["format:c", "format:ruby"]


### PR DESCRIPTION
Move dependencies related to style and documentation into a separate 'development' group in the Gemfile, and exclude that group from CI wherever possible.

Also remove libyaml-dev from the list of things we install on test containers, because hopefully we don't need it anymore.
