### PR TITLE
Try to simplify pragma related constants

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -196,7 +196,7 @@ module SQLite3
     #
     # Fetch the encoding set on this database
     def encoding
-      prepare("PRAGMA encoding") { |stmt| Encoding.find(stmt.first.first) }
+      Encoding.find super
     end
 
     # Installs (or removes) a block that will be invoked for every access

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -269,7 +269,7 @@ module SQLite3
     end
 
     def encoding=(mode)
-      set_enum_pragma "encoding", mode, ENCODINGS
+      set_string_pragma "encoding", mode, ENCODINGS
     end
 
     def foreign_key_check(*table, &block) # :yields: row
@@ -337,7 +337,7 @@ module SQLite3
     end
 
     def journal_mode=(mode)
-      set_enum_pragma "journal_mode", mode, JOURNAL_MODES
+      set_string_pragma "journal_mode", mode, JOURNAL_MODES
     end
 
     def journal_size_limit
@@ -361,7 +361,7 @@ module SQLite3
     end
 
     def locking_mode=(mode)
-      set_enum_pragma "locking_mode", mode, LOCKING_MODES
+      set_string_pragma "locking_mode", mode, LOCKING_MODES
     end
 
     def max_page_count
@@ -567,7 +567,7 @@ module SQLite3
     end
 
     def wal_checkpoint=(mode)
-      set_enum_pragma "wal_checkpoint", mode, WAL_CHECKPOINTS
+      set_string_pragma "wal_checkpoint", mode, WAL_CHECKPOINTS
     end
 
     def writable_schema=(mode)
@@ -609,6 +609,13 @@ module SQLite3
     end
 
     private
+
+    def set_string_pragma(pragma_name, value, valid_values)
+      valid_values.fetch(value.to_s.downcase) {
+        raise SQLite3::Exception, "unrecognized #{pragma_name} #{value.inspect}"
+      }
+      set_enum_pragma(pragma_name, value, valid_values)
+    end
 
     # Compares two version strings
     def version_compare(v1, v2)

--- a/lib/sqlite3/pragmas.rb
+++ b/lib/sqlite3/pragmas.rb
@@ -60,11 +60,20 @@ module SQLite3
     # have duplicate values. See #synchronous, #default_synchronous,
     # #temp_store, and #default_temp_store for usage examples.
     def set_enum_pragma(name, mode, enums)
-      match = enums.find { |p| p.find { |i| i.to_s.downcase == mode.to_s.downcase } }
+      match = if enums.is_a?(Array)
+        # maybe deprecate this?
+        enums.find { |p| p.find { |i| i.to_s.downcase == mode.to_s.downcase } }
+      elsif mode.is_a?(String)
+        enums.fetch(mode.downcase)
+      else
+        mode
+      end
+
       unless match
         raise SQLite3::Exception, "unrecognized #{name} #{mode.inspect}"
       end
-      execute("PRAGMA #{name}='#{match.first.upcase}'")
+
+      execute("PRAGMA #{name}='#{match}'")
     end
 
     # Returns the value of the given pragma as an integer.
@@ -79,26 +88,57 @@ module SQLite3
     end
 
     # The enumeration of valid synchronous modes.
-    SYNCHRONOUS_MODES = [["full", 2], ["normal", 1], ["off", 0]].map(&:freeze).freeze
+    SYNCHRONOUS_MODES = {
+      "full" => 2,
+      "normal" => 1,
+      "off" => 0
+    }.freeze
 
     # The enumeration of valid temp store modes.
-    TEMP_STORE_MODES = [["default", 0], ["file", 1], ["memory", 2]].map(&:freeze).freeze
+    TEMP_STORE_MODES = {
+      "default" => 0,
+      "file" => 1,
+      "memory" => 2
+    }.freeze
 
     # The enumeration of valid auto vacuum modes.
-    AUTO_VACUUM_MODES = [["none", 0], ["full", 1], ["incremental", 2]].map(&:freeze).freeze
+    AUTO_VACUUM_MODES = {
+      "none" => 0,
+      "full" => 1,
+      "incremental" => 2
+    }.freeze
 
     # The list of valid journaling modes.
-    JOURNAL_MODES = [["delete"], ["truncate"], ["persist"], ["memory"],
-      ["wal"], ["off"]].map(&:freeze).freeze
+    JOURNAL_MODES = {
+      "delete" => "delete",
+      "truncate" => "truncate",
+      "persist" => "persist",
+      "memory" => "memory",
+      "wal" => "wal",
+      "off" => "off"
+    }.freeze
 
     # The list of valid locking modes.
-    LOCKING_MODES = [["normal"], ["exclusive"]].map(&:freeze).freeze
+    LOCKING_MODES = {
+      "normal" => "normal",
+      "exclusive" => "exclusive"
+    }.freeze
 
     # The list of valid encodings.
-    ENCODINGS = [["utf-8"], ["utf-16"], ["utf-16le"], ["utf-16be"]].map(&:freeze).freeze
+    ENCODINGS = {
+      "utf-8" => "utf-8",
+      "utf-16" => "utf-16",
+      "utf-16le" => "utf-16le",
+      "utf-16be" => "utf-16be"
+    }.freeze
 
     # The list of valid WAL checkpoints.
-    WAL_CHECKPOINTS = [["passive"], ["full"], ["restart"], ["truncate"]].map(&:freeze).freeze
+    WAL_CHECKPOINTS = {
+      "passive" => "passive",
+      "full" => "full",
+      "restart" => "restart",
+      "truncate" => "truncate"
+    }.freeze
 
     def application_id
       get_int_pragma "application_id"

--- a/test/test_pragmas.rb
+++ b/test/test_pragmas.rb
@@ -27,6 +27,18 @@ module SQLite3
       @db.close
     end
 
+    def test_temp_store_mode
+      @db.temp_store = "memory"
+      assert_equal 2, @db.temp_store
+      @db.temp_store = 1
+      assert_equal 1, @db.temp_store
+    end
+
+    def test_encoding
+      @db.encoding = "utf-16le"
+      assert_equal Encoding.find("utf-16le"), @db.encoding
+    end
+
     def test_pragma_errors
       assert_raises(SQLite3::Exception) do
         @db.set_enum_pragma("foo", "bar", [])

--- a/test/test_pragmas.rb
+++ b/test/test_pragmas.rb
@@ -53,6 +53,12 @@ module SQLite3
       end
     end
 
+    def test_invalid_pragma
+      assert_raises(SQLite3::Exception) do
+        @db.journal_mode = 0
+      end
+    end
+
     def test_get_boolean_pragma
       refute(@db.get_boolean_pragma("read_uncommitted"))
     end


### PR DESCRIPTION
This PR is just trying to simplify pragma related constants.  I guess these constants are used as a kind of lookup table.  I added some regression tests because I saw we're not exercising all cases in the test suite, then refactored the constants to just be hash tables.

I left the very strange array search in `set_enum_pragma` for backwards compatibility, though I think we should deprecate it.

AFAICT, there are two types of pragmas. One uses integers, the other strings.  I think if we changed some of the pragma APIs, we could delete the hash tables that are simply duplicated strings, but I'll do that in a follow up PR.