### PR TITLE
ci: get upstream sqlite-head job green

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true
-          apt-get: tcl-dev # https://sqlite.org/forum/forumpost/45c4862d37
       - run: bundle exec rake compile -- --with-sqlite-source-dir=${GITHUB_WORKSPACE}/sqlite
       - run: bundle exec rake test
 


### PR DESCRIPTION
It's been failing for the past few weeks with linker errors like:

```
/usr/bin/ld: tclsqlite-shell.o: in function `DbProfileHandler':
tclsqlite.c:(.text+0x458): undefined reference to `sqlite3_snprintf'
/usr/bin/ld: tclsqlite-shell.o: in function `tclSqlFunc':
tclsqlite.c:(.text+0x60c): undefined reference to `sqlite3_user_data'
/usr/bin/ld: tclsqlite.c:(.text+0x6f2): undefined reference to `sqlite3_result_text64'
/usr/bin/ld: tclsqlite.c:(.text+0x75e): undefined reference to `sqlite3_value_double'
/usr/bin/ld: tclsqlite.c:(.text+0x78e): undefined reference to `sqlite3_value_type'
/usr/bin/ld: tclsqlite.c:(.text+0x7f9): undefined reference to `sqlite3_result_error'
/usr/bin/ld: tclsqlite.c:(.text+0x824): undefined reference to `sqlite3_value_bytes'
/usr/bin/ld: tclsqlite.c:(.text+0x830): undefined reference to `sqlite3_value_blob'
/usr/bin/ld: tclsqlite.c:(.text+0x854): undefined reference to `sqlite3_value_bytes'
/usr/bin/ld: tclsqlite.c:(.text+0x860): undefined reference to `sqlite3_value_text'
/usr/bin/ld: tclsqlite.c:(.text+0x884): undefined reference to `sqlite3_value_int64'
/usr/bin/ld: tclsqlite.c:(.text+0x959): undefined reference to `sqlite3_result_double'
/usr/bin/ld: tclsqlite.c:(.text+0xa1f): undefined reference to `sqlite3_result_blob'
/usr/bin/ld: tclsqlite.c:(.text+0xa79): undefined reference to `sqlite3_result_int64'
```