### PR TITLE
feat: aarch64-mingw-ucrt support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
         platform:
           - aarch64-linux-gnu
           - aarch64-linux-musl
+          - aarch64-mingw-ucrt
           - arm-linux-gnu
           - arm-linux-musl
           - arm64-darwin
@@ -342,6 +343,9 @@ jobs:
             platform: arm64-darwin
           - os: windows-latest
             platform: x64-mingw-ucrt
+          - os: windows-11-arm
+            platform: aarch64-mingw-ucrt
+            ruby: 3.4
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,6 +11,7 @@ In v2.0.0 and later, native (precompiled) gems are available for recent Ruby ver
 
 - `aarch64-linux-gnu` (requires: glibc >= 2.29)
 - `aarch64-linux-musl`
+- `aarch64-mingw-ucrt` (requires: ruby >= 3.4)
 - `arm-linux-gnu` (requires: glibc >= 2.29)
 - `arm-linux-musl`
 - `arm64-darwin`

--- a/bin/test-gem-file-contents
+++ b/bin/test-gem-file-contents
@@ -65,7 +65,13 @@ Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
 puts "Testing '#{gemfile}' (#{gemspec.platform})"
 describe File.basename(gemfile) do
-  let(:supported_ruby_versions) { ["3.1", "3.2", "3.3", "3.4"] }
+  let(:supported_ruby_versions) do
+    if gemspec.platform.to_s == "aarch64-mingw-ucrt"
+      ["3.4"]
+    else
+      ["3.1", "3.2", "3.3", "3.4"]
+    end
+  end
 
   describe "setup" do
     it "gemfile contains some files" do

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -155,6 +155,14 @@ module Sqlite3
             recipe.target = File.join(package_root_dir, "ports")
             recipe.patch_files = Dir[File.join(package_root_dir, "patches", "*.patch")].sort
           end
+
+          # Fix host triplet for Windows ARM64 (native or cross-compilation)
+          if RbConfig::CONFIG["target_os"].match?(/mingw/)
+            case RbConfig::CONFIG["arch"]
+            when /aarch64/
+              recipe.host = "aarch64-w64-mingw32"
+            end
+          end
         end
       end
 

--- a/rakelib/native.rake
+++ b/rakelib/native.rake
@@ -9,6 +9,7 @@ require "yaml"
 cross_platforms = [
   "aarch64-linux-gnu",
   "aarch64-linux-musl",
+  "aarch64-mingw-ucrt",
   "arm-linux-gnu",
   "arm-linux-musl",
   "x86-linux-gnu",


### PR DESCRIPTION
👋🏾 

Would be nice to get a precompiled gem for `aarch64-mingw-ucrt` now that rake-compiler-dock has support 

https://github.com/rake-compiler/rake-compiler-dock/releases/tag/v1.10.0

Similar to 

https://github.com/sparklemotion/nokogiri/pull/3530

There is an existing PR for the required version of rake-compiler-dock #647 

cross compiled with the applied fix on a macos m4 machine, and successfully installed in a windows-11-arm github actions vm and locally running VM with utm/qemu

There are some test failures regarding support for earlier ruby versions. There is only windows on arm support for Ruby 3.4 provided as part of the rubyinstaller toolking.

PS. If there is a better way to solve this, feel free to close this down, or suggest another approach. This worked for me in trying to add `windows-11-arm` coverage to some tooling which makes our ruby rack app, available via a github action on any supported actions runner, mainly for CI testing on platforms where docker isn't available.

PPS. I assume `feat` isn't the right classification for this change!

Cheers!