### PR TITLE
Fix the inconsistent names in SQLite3::Statement#memused RDoc call-seq

### DIFF
--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -628,7 +628,7 @@ stat_for(VALUE self, VALUE key)
 }
 
 #ifdef SQLITE_STMTSTATUS_MEMUSED
-/* call-seq: stmt.memory_used
+/* call-seq: stmt.memused
  *
  * Return the approximate number of bytes of heap memory used to store the prepared statement
  */


### PR DESCRIPTION
It should be `memused`.