### PR TITLE
build(deps): update vendored sqlite to 3.53.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 581215771b32ea4c4062e6fb9842c4aa43d0a7fb2b6670ff6fa4ebb807781204
+  # 60c4b08c6729761e488d185e0d52411da10b14c72b53ada6936dc5eea225cefe
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3510300.tar.gz
-  # 581215771b32ea4c4062e6fb9842c4aa43d0a7fb2b6670ff6fa4ebb807781204  ports/archives/sqlite-autoconf-3510300.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3530000.tar.gz
+  # 60c4b08c6729761e488d185e0d52411da10b14c72b53ada6936dc5eea225cefe  ports/archives/sqlite-autoconf-3530000.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3510300.tar.gz
-  # 81f5be397049b0cae1b167f2225af7646fc0f82e4a9b3c48c9ea3a533e21d77a  ports/archives/sqlite-autoconf-3510300.tar.gz
-  version: "3.51.3"
+  # $ sha256sum ports/archives/sqlite-autoconf-3530000.tar.gz
+  # 851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a  ports/archives/sqlite-autoconf-3530000.tar.gz
+  version: "3.53.0"
   files:
-    - url: "https://sqlite.org/2026/sqlite-autoconf-3510300.tar.gz"
-      sha256: "81f5be397049b0cae1b167f2225af7646fc0f82e4a9b3c48c9ea3a533e21d77a"
+    - url: "https://sqlite.org/2026/sqlite-autoconf-3530000.tar.gz"
+      sha256: "851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a"


### PR DESCRIPTION
## Summary
- Update vendored sqlite from 3.51.3 to 3.53.0
- SHA3-256 checksum verified against https://sqlite.org/download.html
- Release notes: https://sqlite.org/releaselog/3_53_0.html