### PR TITLE
dep: update vendored sqlite to 3.53.1

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 60c4b08c6729761e488d185e0d52411da10b14c72b53ada6936dc5eea225cefe
+  # 36ca143645cf76997d07b66e9244c636b8ccdec64a1d50558259c4e415e6558b
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3530000.tar.gz
-  # 60c4b08c6729761e488d185e0d52411da10b14c72b53ada6936dc5eea225cefe  ports/archives/sqlite-autoconf-3530000.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3530100.tar.gz
+  # 36ca143645cf76997d07b66e9244c636b8ccdec64a1d50558259c4e415e6558b  ports/archives/sqlite-autoconf-3530100.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3530000.tar.gz
-  # 851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a  ports/archives/sqlite-autoconf-3530000.tar.gz
-  version: "3.53.0"
+  # $ sha256sum ports/archives/sqlite-autoconf-3530100.tar.gz
+  # 83e6b2020a034e9a7ad4a72feea59e1ad52f162e09cbd26735a3ffb98359fc4f  ports/archives/sqlite-autoconf-3530100.tar.gz
+  version: "3.53.1"
   files:
-    - url: "https://sqlite.org/2026/sqlite-autoconf-3530000.tar.gz"
-      sha256: "851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a"
+    - url: "https://sqlite.org/2026/sqlite-autoconf-3530100.tar.gz"
+      sha256: "83e6b2020a034e9a7ad4a72feea59e1ad52f162e09cbd26735a3ffb98359fc4f"


### PR DESCRIPTION
See https://www.sqlite.org/releaselog/3_53_1.html for the full changelog.