### PR TITLE
For sqlcipher builds, prefer sqlcipher's header

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -105,10 +105,10 @@ module Sqlite3
       def configure_extension
         append_cflags("-fvisibility=hidden") # see https://github.com/rake-compiler/rake-compiler-dock/issues/87
 
-        if find_header("sqlite3.h")
-          # noop
-        elsif sqlcipher? && find_header("sqlcipher/sqlite3.h")
+        if sqlcipher? && find_header("sqlcipher/sqlite3.h")
           append_cppflags("-DUSING_SQLCIPHER_INC_SUBDIR")
+        elsif find_header("sqlite3.h")
+          # noop
         else
           abort_could_not_find("sqlite3.h")
         end


### PR DESCRIPTION
Some systems may have sqlite *and* sqlcipher installed, which is what happened in May 2026 when the sqlcipher vcpkg port started pulling in the sqlite3 port as a dependency.

e.g. https://github.com/sparklemotion/sqlite3-ruby/actions/runs/25789505372/job/75751706889