### PR TITLE
dep: update vendored sqlite to 3.53.2

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 sqlite3:
   # checksum verified by first checking the published sha3(256) checksum against https://sqlite.org/download.html:
-  # 36ca143645cf76997d07b66e9244c636b8ccdec64a1d50558259c4e415e6558b
+  # 025328da165109f48abccc6e7478508060804412bed2bd81d47e98ba1b72983b
   #
-  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3530100.tar.gz
-  # 36ca143645cf76997d07b66e9244c636b8ccdec64a1d50558259c4e415e6558b  ports/archives/sqlite-autoconf-3530100.tar.gz
+  # $ sha3sum -a 256 ports/archives/sqlite-autoconf-3530200.tar.gz
+  # 025328da165109f48abccc6e7478508060804412bed2bd81d47e98ba1b72983b  ports/archives/sqlite-autoconf-3530200.tar.gz
   #
-  # $ sha256sum ports/archives/sqlite-autoconf-3530100.tar.gz
-  # 83e6b2020a034e9a7ad4a72feea59e1ad52f162e09cbd26735a3ffb98359fc4f  ports/archives/sqlite-autoconf-3530100.tar.gz
-  version: "3.53.1"
+  # $ sha256sum ports/archives/sqlite-autoconf-3530200.tar.gz
+  # 588ad51949419a56ebe81fe56193d510c559eb94c9a57748387860b5d3069316  ports/archives/sqlite-autoconf-3530200.tar.gz
+  version: "3.53.2"
   files:
-    - url: "https://sqlite.org/2026/sqlite-autoconf-3530100.tar.gz"
-      sha256: "83e6b2020a034e9a7ad4a72feea59e1ad52f162e09cbd26735a3ffb98359fc4f"
+    - url: "https://sqlite.org/2026/sqlite-autoconf-3530200.tar.gz"
+      sha256: "588ad51949419a56ebe81fe56193d510c559eb94c9a57748387860b5d3069316"


### PR DESCRIPTION
See https://www.sqlite.org/releaselog/3_53_2.html for the full changelog.
