### PR TITLE
Fix use-after-free issue with custom functions

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -528,7 +528,7 @@ define_function_with_flags(VALUE self, VALUE name, VALUE flags)
 
     CHECK(ctx->db, status);
 
-    rb_hash_aset(rb_iv_get(self, "@functions"), name, block);
+    rb_ary_push(rb_iv_get(self, "@functions"), block);
 
     return self;
 }

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -175,7 +175,7 @@ module SQLite3
       @authorizer = nil
       @progress_handler = nil
       @collations = {}
-      @functions = {}
+      @functions = []
       @results_as_hash = options[:results_as_hash]
       @readonly = mode & Constants::Open::READONLY != 0
       @default_transaction_mode = options[:default_transaction_mode] || :deferred
@@ -397,6 +397,8 @@ module SQLite3
     # The block does not return a value directly. Instead, it will invoke
     # the FunctionProxy#result= method on the +func+ parameter and
     # indicate the return value that way.
+    #
+    # A reference to the block will be kept for the lifetime of the database object.
     #
     # Example:
     #

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -463,6 +463,14 @@ module SQLite3
       assert_equal 10, called_with
     end
 
+    def test_redefine_function_with_different_arity_does_not_use_freed_block
+      @db.define_function("f") { |a| "orig" }
+      @db.define_function("f") { |a, b| "new" }
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      assert_equal ["orig"], @db.execute("select f(1)").first
+    end
+
     def test_call_func_arg_type
       called_with = nil
       @db.define_function("hello") do |b, c, d|


### PR DESCRIPTION
when the same function name is used with multiple arities.

ref: https://github.com/sparklemotion/sqlite3-ruby/security/advisories/GHSA-28hh-pr2h-2w89