### PR TITLE
Fix use-after-free issue with aggregate functions

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -198,8 +198,6 @@ sqlite3_rb_close(VALUE self)
 
     close_or_discard_db(ctx);
 
-    rb_iv_set(self, "-aggregators", Qnil);
-
     return self;
 }
 
@@ -211,8 +209,6 @@ sqlite3_rb_discard(VALUE self)
     TypedData_Get_Struct(self, sqlite3Ruby, &database_type, ctx);
 
     discard_db(ctx);
-
-    rb_iv_set(self, "-aggregators", Qnil);
 
     return self;
 }

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -437,6 +437,8 @@ module SQLite3
     # function invocation. It should invoke FunctionProxy#result= to
     # store the result of the function.
     #
+    # A reference to the block will be kept for the lifetime of the database object.
+    #
     # Example:
     #
     #   db.create_aggregate( "lengths", 1 ) do

--- a/test/test_integration_aggregate.rb
+++ b/test/test_integration_aggregate.rb
@@ -363,4 +363,15 @@ class IntegrationAggregateTestCase < SQLite3::TestCase
     assert_equal 33, values[0]
     assert_equal 2145, values[1]
   end
+
+  def test_step_on_statement_whose_database_was_closed_does_not_use_freed_aggregator
+    @db.define_aggregator("accumulate", AccumulateAggregator.new)
+    stmt = @db.prepare("select accumulate(c) from foo")
+
+    @db.close
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    values = stmt.step
+    assert_equal 33, values[0]
+  end
 end


### PR DESCRIPTION
if a statement is used after a soft database close.

ref: https://github.com/sparklemotion/sqlite3-ruby/security/advisories/GHSA-j7fr-3v8c-3qc3