### PR TITLE
Release aggregate instances when sqlite finishes with them

### DIFF
--- a/ext/sqlite3/aggregator.c
+++ b/ext/sqlite3/aggregator.c
@@ -97,7 +97,7 @@ rb_sqlite3_aggregate_instance_destroy(sqlite3_context *ctx)
     VALUE *inst_ptr = sqlite3_aggregate_context(ctx, 0);
     VALUE inst;
 
-    if (!inst_ptr || (inst = *inst_ptr)) {
+    if (!inst_ptr || !(inst = *inst_ptr)) {
         return;
     }
 

--- a/test/test_integration_aggregate.rb
+++ b/test/test_integration_aggregate.rb
@@ -354,6 +354,18 @@ class IntegrationAggregateTestCase < SQLite3::TestCase
     end
   end
 
+  # Used by one test only, so a live count of 1 means just the template.
+  class ReleasableAggregator
+    def step(*args)
+      @sum ||= 0
+      args.each { |a| @sum += a.to_i }
+    end
+
+    def finalize
+      @sum
+    end
+  end
+
   class AccumulateAggregator2
     def step(a, b)
       @sum ||= 1
@@ -394,6 +406,15 @@ class IntegrationAggregateTestCase < SQLite3::TestCase
     values = @db.get_first_row("select accumulate(a), accumulate(c) from foo")
     assert_equal 6, values[0]
     assert_equal 33, values[1]
+  end
+
+  def test_aggregate_instances_are_released_after_each_query
+    @db.define_aggregator("accumulate", ReleasableAggregator.new)
+
+    5.times { assert_equal 33, @db.get_first_value("select accumulate(c) from foo") }
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_equal 1, ObjectSpace.each_object(ReleasableAggregator).count
   end
 
   def test_step_on_statement_whose_database_was_closed_does_not_use_freed_aggregator


### PR DESCRIPTION
The check at the top of the destroy function returns when the aggregate context still holds an instance, which is exactly when there is something to clean up. So instances were never unlinked, and every aggregate call left one behind for as long as the connection stayed open.