### PR TITLE
Declare benchmark dependency so rubocop's CLI runs on Ruby 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,9 @@ group :development do
   gem "rubocop", "1.59.0", require: false
   gem "rubocop-minitest", "0.34.5", require: false
   gem "standard", "1.33.0", require: false
+
+  # rubocop's executable requires "benchmark", which stopped being a default gem
+  # in ruby 4.0. rubocop dropped that require in 1.66.0, so this can go away
+  # whenever we bump past it.
+  gem "benchmark", "0.5.0", require: false
 end


### PR DESCRIPTION
`benchmark` stopped being a default gem in Ruby 4.0, and rubocop 1.59.0's executable requires it. Since it's declared nowhere in the `Gemfile`, `bundle exec rubocop` dies on Ruby 4.0:

```
$ ruby -v
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin23]

$ bundle exec rubocop --version
.../gems/rubocop-1.59.0/exe/rubocop:14: warning: benchmark used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add benchmark to your Gemfile or gemspec to fix this error.
bundler: failed to load command: rubocop (.../bin/rubocop)
.../lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- benchmark (LoadError)
	from .../lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from .../gems/rubocop-1.59.0/exe/rubocop:14:in '<top (required)>'
```

## Scope: this does not break CI

Worth being explicit, since it affects how urgent this is. `require 'benchmark'` appears only in rubocop's `exe/rubocop`. `RuboCop::RakeTask` loads rubocop in-process and never goes through that file, so `rake rubocop` — and therefore the `rubocop` CI job — passes on Ruby 4.0 today and will keep passing. What's broken is the direct CLI: `bundle exec rubocop`, `bundle exec rubocop -a`, and editor/LSP integrations that shell out to it. So this is a local-development papercut, not a red build.

`rubocop-minitest` 0.34.5 and `standard` 1.33.0 are unaffected — neither requires `benchmark`, and `bundle exec standardrb` works as-is.

## Why declare the dependency rather than bump rubocop

rubocop dropped the `benchmark` require in 1.66.0, so a bump is the tidier long-term fix, but it isn't a one-line change here. `standard` 1.33.0 pins `rubocop ~> 1.59.0`, so rubocop can't move without `standard` moving too, and both landing spots cost real churn on Ruby 4.0:

- **rubocop 1.66.0 + standard 1.41.0** (the earliest version pair that clears the require): 26 new `Style/ArgumentsForwarding` offenses in `lib/sqlite3/pragmas.rb`, plus `Style/EmptyElse` crashing internally on 9 sites (`An error occurred while Style/EmptyElse cop was inspecting ...`).
- **rubocop 1.88.0 + standard 1.56.0 + rubocop-minitest 0.40.0** (current latest): only 2 offenses, but it also needs `.rubocop.yml` migrated from `require:` to `plugins:` for all five extensions and a decision on the new `Minitest/Focus` cop.

Either is a reasonable follow-up, but both are a lint-config change rather than a build fix, and this repo bumps its dev pins through Dependabot anyway. Declaring the dependency restores the CLI now and changes nothing else. `benchmark` 0.5.0 requires Ruby >= 2.1, so it's safe across the supported matrix, and the comment notes it can be dropped once rubocop moves past 1.66.0.

## Verification

On Ruby 4.0.6, after the change:

```
$ bundle exec rubocop --version
1.59.0

$ bundle exec rake rubocop
Running RuboCop...
Inspecting 42 files
..........................................

42 files inspected, no offenses detected
```

The offense set is unchanged. Dumping the resolved configuration before and after (`rubocop --show-cops`) gives byte-identical output modulo the absolute project path — 653 cops both ways — so no cop loading or configuration changed.

`Gemfile.lock` is gitignored in this repo, so there's nothing to commit alongside.
